### PR TITLE
fix: prevent shift cards from occluding Quick Action buttons

### DIFF
--- a/ShiftScheduler/Views/TodayView.swift
+++ b/ShiftScheduler/Views/TodayView.swift
@@ -403,29 +403,18 @@ struct TodayView: View {
                                     }
 
                                     if !todayShifts.isEmpty {
-                                        ZStack(alignment: .top) {
-                                            // Background layout with divider and quick actions
-                                            VStack(spacing: 16) {
-                                                Spacer()
-                                                    .frame(height: 200)
+                                        VStack(spacing: 16) {
+                                            MultiShiftCarousel(shifts: todayShifts)
+                                                .frame(minHeight: 200)
 
-                                                // Divider between shift and quick actions
-                                                Divider()
-                                                    .padding(.vertical, 4)
+                                            // Divider between shift and quick actions
+                                            Divider()
+                                                .padding(.vertical, 4)
 
-                                                // Quick Actions Section (show for first shift)
-                                                if let firstShift = todayShifts.first {
-                                                    QuickActionsView(shift: firstShift)
-                                                }
+                                            // Quick Actions Section (show for first shift)
+                                            if let firstShift = todayShifts.first {
+                                                QuickActionsView(shift: firstShift)
                                             }
-
-                                            // Carousel overlays on top - can expand and occlude quick actions
-                                            VStack {
-                                                MultiShiftCarousel(shifts: todayShifts)
-                                                    .frame(minHeight: 200)
-                                                Spacer()
-                                            }
-                                            .zIndex(1)
                                         }
                                         .offset(x: todayCardOffset)
                                         .opacity(todayCardOpacity)


### PR DESCRIPTION
The ZStack overlay layout with zIndex(1) on the carousel caused ALL
shift cards to overlay the Quick Action buttons, not just expanded
sick day notes. Replaced with a VStack so the carousel and Quick
Actions flow naturally — buttons are always visible below the card.

https://claude.ai/code/session_011u7B7amsjPRkbjLrtBwzJ6