### PR TITLE
feat: complete CLI interface (Phases 2-5) with agent-friendly UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,9 @@ iOSInjectionProject/
 # Build and test output
 test_output.txt
 *_output.txt
+
+# macOS
+.DS_Store
+
+# Swift Package Manager
+Package.resolved

--- a/CLI_IMPLEMENTATION_PLAN.md
+++ b/CLI_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,286 @@
+# CLI Implementation Plan
+
+A macOS command-line interface for ShiftScheduler that shares data with the iOS app via `~/Documents/ShiftSchedulerData/` and calendar via EventKit.
+
+**Key decisions:**
+- **Architecture**: Thin CLI layer over services (not Redux, not raw service calls)
+- **Project structure**: Swift Package (Package.swift) with swift-argument-parser
+- **Calendar**: Full EventKit integration (read + write)
+- **Output**: Human-readable tables by default, `--json` flag for machine-readable output
+
+---
+
+## Project Structure
+
+```
+ShiftScheduler/
+├── Package.swift                          # SPM manifest
+├── Sources/
+│   └── ShiftSchedulerCLI/                 # CLI executable
+│       ├── ShiftSchedulerCLI.swift        # Entry point + root command
+│       ├── CLIController.swift            # Thin orchestration layer over services
+│       ├── OutputFormatter.swift          # Human-readable + JSON formatting
+│       ├── Commands/
+│       │   ├── TodayCommand.swift         # `shift today`
+│       │   ├── ScheduleCommand.swift      # `shift schedule list|add|delete`
+│       │   ├── ShiftTypesCommand.swift    # `shift types list|add|delete`
+│       │   ├── LocationsCommand.swift     # `shift locations list|add|delete`
+│       │   ├── ChangeLogCommand.swift     # `shift log list|purge`
+│       │   └── ProfileCommand.swift       # `shift profile show|set`
+│       └── Utilities/
+│           └── DateParsing.swift          # CLI date argument parsing
+├── ShiftScheduler/                        # Existing iOS app (unchanged)
+├── ShiftScheduler.xcodeproj/              # Existing (unchanged)
+```
+
+### Package.swift
+
+- `ShiftSchedulerCore` library target references existing iOS source files via `path: "ShiftScheduler"` with explicit `sources` subdirectories (Models, Domain, Persistence, Repositories, Protocols, Services, Redux/Services, Redux/Errors)
+- `ShiftSchedulerCLI` executable target depends on `ShiftSchedulerCore` and `swift-argument-parser` (~> 1.3)
+- Platform: macOS 14+
+
+### Shared Code
+
+**Domain Models** (no changes needed):
+- `ShiftScheduler/Models/` — Location, ShiftType, ScheduledShift, ShiftDuration, ScheduledShiftData
+- `ShiftScheduler/Domain/` — ChangeLogEntry, ChangeType, ShiftSnapshot, UserProfile, ChangeLogRetentionPolicy, UndoRedoStacks
+
+**Persistence** (no changes needed):
+- `ShiftScheduler/Persistence/` — ShiftTypeRepository, LocationRepository, ChangeLogRepository, UserProfileRepository, CloudKitManager
+- `ShiftScheduler/Repositories/` — ChangeLogRepositoryProtocol
+
+**Services** (no changes needed):
+- `ShiftScheduler/Redux/Services/` — PersistenceService, CalendarService, CurrentDayService, ShiftSwitchService, ServiceContainer + all protocols
+
+**Platform guards applied:**
+- `ShiftScheduler/Services/TimeChangeService.swift` — `#if canImport(UIKit)` with no-op macOS fallback
+
+**Not needed for CLI:**
+- All SwiftUI views (`ShiftScheduler/Views/`)
+- Redux State/Action/Reducer/Middleware files
+- `ReduxStoreEnvironment.swift`, `ShiftSchedulerApp.swift`
+
+---
+
+## Command Hierarchy
+
+```
+shift-scheduler                              # Root command (shows help)
+├── today                                    # Show today's shifts
+│   └── --json                               # JSON output
+├── schedule                                 # Schedule operations
+│   ├── list [--from DATE] [--to DATE]       # List shifts in range (default: current month)
+│   │   └── --json
+│   ├── add --date DATE --type TYPE-ID [--notes "..."]   # Add shift to calendar
+│   └── delete --event-id ID                 # Delete shift from calendar
+├── types                                    # Shift type management
+│   ├── list [--json]                        # List all shift types
+│   ├── add --title "..." --symbol "..." --location LOC-ID [--start HH:MM --end HH:MM | --all-day]
+│   ├── edit --id ID [--title "..."] [--symbol "..."]
+│   └── delete --id ID
+├── locations                                # Location management
+│   ├── list [--json]
+│   ├── add --name "..." --address "..."
+│   ├── edit --id ID [--name "..."] [--address "..."]
+│   └── delete --id ID
+├── log                                      # Change log
+│   ├── list [--limit N] [--json]
+│   └── purge --older-than DAYS
+├── profile                                  # User profile
+│   ├── show [--json]
+│   └── set --name "..."
+└── auth                                     # Calendar authorization
+    ├── status                               # Check EventKit authorization
+    └── request                              # Request calendar access
+```
+
+### Global Options
+- `--json` — Output JSON instead of human-readable format
+- `--data-dir PATH` — Override data directory (default: `~/Documents/ShiftSchedulerData/`)
+
+---
+
+## CLIController Architecture
+
+```swift
+/// Thin orchestration layer - not Redux, not raw services
+/// Combines service calls with business logic for CLI operations
+final class CLIController {
+    let persistence: PersistenceServiceProtocol
+    let calendar: CalendarServiceProtocol
+    let currentDay: CurrentDayServiceProtocol
+
+    init(dataDirectory: URL? = nil) {
+        self.persistence = PersistenceService(directoryURL: dataDirectory)
+        self.calendar = CalendarService()
+        self.currentDay = CurrentDayService()
+    }
+
+    // Example: add shift with audit trail
+    func addShift(date: Date, shiftTypeId: UUID, notes: String?) async throws -> ScheduledShift {
+        let shiftTypes = try await persistence.loadShiftTypes()
+        guard let shiftType = shiftTypes.first(where: { $0.id == shiftTypeId }) else {
+            throw CLIError.shiftTypeNotFound(shiftTypeId)
+        }
+        let shift = try await calendar.createShiftEvent(date: date, shiftType: shiftType, notes: notes)
+        let entry = ChangeLogEntry(/* ... */)
+        try await persistence.addChangeLogEntry(entry)
+        return shift
+    }
+}
+```
+
+---
+
+## EventKit on macOS
+
+1. **Authorization**: On macOS, `EKEventStore.requestFullAccessToEvents()` shows a system dialog. The CLI checks auth status first and provides clear terminal output if denied.
+2. **Shared Calendar**: The iOS app creates a calendar named `"functioncraft.ShiftScheduler"`. The CLI looks for/creates the same calendar, enabling shared shift data.
+3. **No UIKit dependency**: `CalendarService.swift` uses `EventKit` (not `EventKitUI`), so it works on macOS without changes.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Foundation (Package.swift + Core library) ✅ COMPLETE
+
+**Work:**
+1. Create `Package.swift` with target definitions
+2. Set up `ShiftSchedulerCore` referencing existing files
+3. Resolve platform-specific issues (`#if canImport` guards)
+
+**Acceptance Criteria:**
+- [x] `Package.swift` exists with `ShiftSchedulerCore` library and `ShiftSchedulerCLI` executable targets
+- [x] `swift-argument-parser` declared as dependency
+- [x] All domain models accessible from the library target
+- [x] All persistence repositories compile in the library target
+- [x] All service protocols and implementations compile in the library target
+- [x] No unguarded `import SwiftUI` or `import UIKit` in `ShiftSchedulerCore`
+- [x] Minimal `ShiftSchedulerCLI.swift` entry point created
+
+**Validation:**
+```bash
+swift build --target ShiftSchedulerCore 2>&1 | tail -1
+# Expected: "Build complete!"
+```
+
+---
+
+### Phase 2: CLI Skeleton
+
+**Work:**
+1. Create `CLIController.swift` with service initialization
+2. Create `OutputFormatter.swift` (table + JSON modes)
+3. Implement `today` command as proof-of-concept
+4. Register all subcommand stubs (types, locations, schedule, log, profile, auth)
+
+**Acceptance Criteria:**
+- [ ] `swift build` compiles the full CLI executable with zero errors
+- [ ] `swift run shift-scheduler --help` prints root help with all subcommand names
+- [ ] `swift run shift-scheduler today` executes without crashing
+- [ ] `swift run shift-scheduler today --json` produces valid JSON output
+- [ ] `CLIController` initializes `PersistenceService`, `CalendarService`, and `CurrentDayService`
+- [ ] `OutputFormatter` has both table and JSON rendering paths
+- [ ] All subcommands registered and show `--help` output
+
+**Validation:**
+```bash
+swift run shift-scheduler --help
+swift run shift-scheduler today
+swift run shift-scheduler today --json | jq .
+swift run shift-scheduler types --help
+```
+
+---
+
+### Phase 3: Data Management Commands
+
+**Work:**
+1. `types list|add|edit|delete` — full CRUD for shift types
+2. `locations list|add|edit|delete` — full CRUD for locations
+3. `profile show|set` — user profile management
+4. `log list|purge` — change log viewing and cleanup
+
+**Acceptance Criteria:**
+- [ ] **Shift Types CRUD:** list (table + JSON), add (with time or all-day), edit, delete (with confirmation). Persists to `shiftTypes.json`.
+- [ ] **Locations CRUD:** list, add, edit, delete. Persists to `locations.json`.
+- [ ] **Profile:** show (name, retention policy), set display name.
+- [ ] **Change Log:** list with `--limit`, purge with `--older-than` days.
+- [ ] All commands support `--json` flag
+- [ ] Invalid arguments produce clear error messages
+
+**Validation:**
+```bash
+# Round-trip test
+swift run shift-scheduler locations add --name "Test" --address "123 Test St"
+swift run shift-scheduler locations list --json | jq '.[].name'
+swift run shift-scheduler locations delete --id <ID>
+```
+
+---
+
+### Phase 4: Calendar Commands
+
+**Work:**
+1. `auth status|request` — check and request EventKit authorization
+2. `schedule list` — list shifts with date range filtering
+3. `schedule add` — create calendar events
+4. `schedule delete` — remove calendar events
+
+**Acceptance Criteria:**
+- [ ] `auth status` reports EventKit authorization state
+- [ ] `auth request` triggers macOS authorization dialog
+- [ ] `schedule list` shows current month by default, supports `--from`/`--to` date range
+- [ ] `schedule add` creates calendar event with optional notes, persists ChangeLogEntry
+- [ ] `schedule delete` removes event with confirmation, persists ChangeLogEntry
+- [ ] Date arguments accept `YYYY-MM-DD`, `today`, `tomorrow`
+- [ ] All commands support `--json` flag
+
+**Validation:**
+```bash
+swift run shift-scheduler auth status
+swift run shift-scheduler schedule list --from 2026-03-01 --to 2026-03-31
+swift run shift-scheduler schedule add --date 2026-04-15 --type <ID>
+swift run shift-scheduler schedule delete --event-id <EVENT-ID>
+swift run shift-scheduler log list --limit 2
+```
+
+---
+
+### Phase 5: Polish
+
+**Work:**
+1. ANSI color output for shift symbols and status
+2. Comprehensive error messages and help text
+3. Date parsing utilities (relative dates: `+3d`, `-1w`)
+4. `--data-dir` global option support
+5. `--no-color` flag and auto-detection of non-TTY output
+
+**Acceptance Criteria:**
+- [ ] Terminal output uses colors; disabled when piped or `--no-color` set
+- [ ] Clear error messages with actionable suggestions (e.g., "Run 'shift-scheduler types list'...")
+- [ ] All error messages exit with non-zero status code
+- [ ] Date parsing supports: `YYYY-MM-DD`, `today`, `tomorrow`, `+3d`, `-1w`
+- [ ] `--data-dir` overrides default data directory
+- [ ] Help text is well-formatted with usage examples
+
+**Validation:**
+```bash
+swift run shift-scheduler types list          # Colored output
+swift run shift-scheduler types list | cat    # No ANSI codes
+swift run shift-scheduler schedule list --from today --to +7d
+swift run shift-scheduler --data-dir /tmp/test types list
+swift run shift-scheduler types delete --id "not-a-uuid"  # Clear error, exit 1
+```
+
+---
+
+## Key Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Existing files have `import SwiftUI` or UIKit | Add `#if canImport` guards (done in Phase 1) |
+| CloudKitManager may not compile on macOS CLI | Make it optional or stub for CLI |
+| `@Observable` on Store requires macOS 14+ | CLI doesn't use Store — only services and models |
+| EventKit auth dialog in terminal context | `auth` subcommand handles explicitly |
+| SPM path references to `ShiftScheduler/` sources | Use `path:` parameter in Package.swift targets |

--- a/CLI_IMPLEMENTATION_PLAN.md
+++ b/CLI_IMPLEMENTATION_PLAN.md
@@ -1,12 +1,27 @@
 # CLI Implementation Plan
 
-A macOS command-line interface for ShiftScheduler that shares data with the iOS app via `~/Documents/ShiftSchedulerData/` and calendar via EventKit.
+**Status: Implemented** (July 2026). This document describes the shipped design;
+deviations from the original plan are noted inline.
+
+A macOS command-line interface for ShiftScheduler. Reference data (shift types,
+locations, profile, change log) is stored as JSON in `~/Documents/ShiftSchedulerData/`
+on the Mac running the CLI; scheduled shifts live in the shared
+`functioncraft.ShiftScheduler` EventKit calendar, which syncs with the iOS app
+when hosted on iCloud. Reference data additionally syncs through CloudKit where
+entitlements allow (i.e., in the iOS app — see "CloudKit on macOS CLI" below).
 
 **Key decisions:**
-- **Architecture**: Thin CLI layer over services (not Redux, not raw service calls)
+- **Architecture**: Thin CLI layer (`CLIController`) over the Redux service implementations (not Redux itself)
 - **Project structure**: Swift Package (Package.swift) with swift-argument-parser
+- **Single-module target** *(deviation)*: the app sources have no `public` API, so a
+  separate `ShiftSchedulerCore` library module was unusable from a CLI module without
+  publicizing dozens of types. The executable target compiles the app's domain,
+  persistence, and service sources together with the CLI sources instead.
 - **Calendar**: Full EventKit integration (read + write)
 - **Output**: Human-readable tables by default, `--json` flag for machine-readable output
+- **Agent-friendly**: `--force` on destructive commands, confirmation prompts fail fast
+  (never hang) without a TTY, errors respect `--json` on stderr, exit codes documented
+  in root help, usage examples in every command's help text
 
 ---
 
@@ -14,273 +29,124 @@ A macOS command-line interface for ShiftScheduler that shares data with the iOS 
 
 ```
 ShiftScheduler/
-├── Package.swift                          # SPM manifest
+├── Package.swift                          # SPM manifest (single executable target)
 ├── Sources/
-│   └── ShiftSchedulerCLI/                 # CLI executable
+│   └── ShiftSchedulerCLI/                 # CLI sources
 │       ├── ShiftSchedulerCLI.swift        # Entry point + root command
 │       ├── CLIController.swift            # Thin orchestration layer over services
-│       ├── OutputFormatter.swift          # Human-readable + JSON formatting
-│       ├── Commands/
-│       │   ├── TodayCommand.swift         # `shift today`
-│       │   ├── ScheduleCommand.swift      # `shift schedule list|add|delete`
-│       │   ├── ShiftTypesCommand.swift    # `shift types list|add|delete`
-│       │   ├── LocationsCommand.swift     # `shift locations list|add|delete`
-│       │   ├── ChangeLogCommand.swift     # `shift log list|purge`
-│       │   └── ProfileCommand.swift       # `shift profile show|set`
-│       └── Utilities/
-│           └── DateParsing.swift          # CLI date argument parsing
-├── ShiftScheduler/                        # Existing iOS app (unchanged)
+│       ├── CLIError.swift                 # CLI error types with suggestions
+│       ├── GlobalOptions.swift            # --json/--data-dir, error output, confirmations
+│       ├── OutputFormatter.swift          # Table rendering + stable JSON DTOs
+│       ├── DateParsing.swift              # CLI date/time argument parsing
+│       └── Commands/
+│           ├── TodayCommand.swift         # shift-scheduler today
+│           ├── ScheduleCommand.swift      # schedule list|add|edit|delete|switch
+│           ├── TypesCommand.swift         # types list|add|edit|delete
+│           ├── LocationsCommand.swift     # locations list|add|edit|delete
+│           ├── LogCommand.swift           # log list|purge
+│           ├── ProfileCommand.swift       # profile show|set
+│           ├── AuthCommand.swift          # auth status|request
+│           └── UndoRedoCommands.swift     # undo, redo
+├── ShiftScheduler/                        # Existing iOS app (sources shared with CLI)
 ├── ShiftScheduler.xcodeproj/              # Existing (unchanged)
 ```
 
 ### Package.swift
 
-- `ShiftSchedulerCore` library target references existing iOS source files via `path: "ShiftScheduler"` with explicit `sources` subdirectories (Models, Domain, Persistence, Repositories, Protocols, Services, Redux/Services, Redux/Errors)
-- `ShiftSchedulerCLI` executable target depends on `ShiftSchedulerCore` and `swift-argument-parser` (~> 1.3)
-- Platform: macOS 14+
+- Single `ShiftSchedulerCLI` executable target with `path: "."` and an explicit
+  `sources:` list covering Models, Domain, Persistence, Repositories, Protocols,
+  Services, Redux/Services, Redux/Errors, and Sources/ShiftSchedulerCLI
+- Excludes `Redux/Services/Mocks` (test doubles) and `ServiceContainer.swift`
+  (app-level DI container that references the mocks)
+- `swift-argument-parser` (~> 1.3); platform macOS 14+
 
 ### Shared Code
 
-**Domain Models** (no changes needed):
-- `ShiftScheduler/Models/` — Location, ShiftType, ScheduledShift, ShiftDuration, ScheduledShiftData
-- `ShiftScheduler/Domain/` — ChangeLogEntry, ChangeType, ShiftSnapshot, UserProfile, ChangeLogRetentionPolicy, UndoRedoStacks
-
-**Persistence** (no changes needed):
-- `ShiftScheduler/Persistence/` — ShiftTypeRepository, LocationRepository, ChangeLogRepository, UserProfileRepository, CloudKitManager
-- `ShiftScheduler/Repositories/` — ChangeLogRepositoryProtocol
-
-**Services** (no changes needed):
-- `ShiftScheduler/Redux/Services/` — PersistenceService, CalendarService, CurrentDayService, ShiftSwitchService, ServiceContainer + all protocols
-
-**Platform guards applied:**
+Compiled directly into the executable, unchanged except where noted:
+- `ShiftScheduler/Models/`, `ShiftScheduler/Domain/` — domain models
+- `ShiftScheduler/Persistence/` — JSON repositories (+ CloudKitManager, gated; see below)
+- `ShiftScheduler/Redux/Services/` — PersistenceService, CalendarService, CurrentDayService, ShiftSwitchService
 - `ShiftScheduler/Services/TimeChangeService.swift` — `#if canImport(UIKit)` with no-op macOS fallback
 
-**Not needed for CLI:**
-- All SwiftUI views (`ShiftScheduler/Views/`)
-- Redux State/Action/Reducer/Middleware files
-- `ReduxStoreEnvironment.swift`, `ShiftSchedulerApp.swift`
+---
+
+## Command Hierarchy (as shipped)
+
+```
+shift-scheduler                              # Root command (help, exit codes, examples)
+├── today                                    # Today's shifts
+├── schedule
+│   ├── list [--from DATE] [--to DATE]       # Default: current month; --to inclusive
+│   ├── add --date DATE --type REF [--notes]
+│   ├── edit --event-id ID --notes "..."     # Replace/clear shift notes
+│   ├── delete --event-id ID [--force] [--reason]
+│   └── switch --event-id ID --to REF [--reason]
+├── types    list | add | edit | delete
+├── locations list | add | edit | delete     # delete refuses while referenced by types
+├── log      list [--limit N] | purge --older-than DAYS [--force]
+├── profile  show | set [--name] [--retention] [--auto-purge]
+├── auth     status | request
+├── undo                                     # Reverts last add/delete/switch via snapshots
+└── redo
+```
+
+- Every leaf command supports `--json` and `--data-dir PATH`.
+- Type/location references (`REF`) accept UUID, title/name, or symbol; ambiguous
+  matches fail with the candidate list.
+- `schedule add|delete|switch` write ChangeLogEntry records and maintain the
+  undo/redo stacks (`undoredo_stacks.json`), same files the iOS app uses.
+- Undo/redo re-locates the calendar event by date + shift type from the change-log
+  snapshots (ChangeLogEntry does not store event identifiers).
 
 ---
 
-## Command Hierarchy
+## CloudKit on macOS CLI
 
-```
-shift-scheduler                              # Root command (shows help)
-├── today                                    # Show today's shifts
-│   └── --json                               # JSON output
-├── schedule                                 # Schedule operations
-│   ├── list [--from DATE] [--to DATE]       # List shifts in range (default: current month)
-│   │   └── --json
-│   ├── add --date DATE --type TYPE-ID [--notes "..."]   # Add shift to calendar
-│   └── delete --event-id ID                 # Delete shift from calendar
-├── types                                    # Shift type management
-│   ├── list [--json]                        # List all shift types
-│   ├── add --title "..." --symbol "..." --location LOC-ID [--start HH:MM --end HH:MM | --all-day]
-│   ├── edit --id ID [--title "..."] [--symbol "..."]
-│   └── delete --id ID
-├── locations                                # Location management
-│   ├── list [--json]
-│   ├── add --name "..." --address "..."
-│   ├── edit --id ID [--name "..."] [--address "..."]
-│   └── delete --id ID
-├── log                                      # Change log
-│   ├── list [--limit N] [--json]
-│   └── purge --older-than DAYS
-├── profile                                  # User profile
-│   ├── show [--json]
-│   └── set --name "..."
-└── auth                                     # Calendar authorization
-    ├── status                               # Check EventKit authorization
-    └── request                              # Request calendar access
-```
+CloudKit requires a `com.apple.developer.icloud-services` entitlement. Unbundled
+CLI processes don't have one, and `CKContainer` **traps** (uncatchable `brk`) when
+used without it. `CloudKitManager` therefore:
+- creates its `CKContainer` lazily, and
+- exposes `isSyncAvailable` (false under `#if SWIFT_PACKAGE`), checked by
+  `checkAccountStatus()`, which every operation calls first.
 
-### Global Options
-- `--json` — Output JSON instead of human-readable format
-- `--data-dir PATH` — Override data directory (default: `~/Documents/ShiftSchedulerData/`)
-
----
-
-## CLIController Architecture
-
-```swift
-/// Thin orchestration layer - not Redux, not raw services
-/// Combines service calls with business logic for CLI operations
-final class CLIController {
-    let persistence: PersistenceServiceProtocol
-    let calendar: CalendarServiceProtocol
-    let currentDay: CurrentDayServiceProtocol
-
-    init(dataDirectory: URL? = nil) {
-        self.persistence = PersistenceService(directoryURL: dataDirectory)
-        self.calendar = CalendarService()
-        self.currentDay = CurrentDayService()
-    }
-
-    // Example: add shift with audit trail
-    func addShift(date: Date, shiftTypeId: UUID, notes: String?) async throws -> ScheduledShift {
-        let shiftTypes = try await persistence.loadShiftTypes()
-        guard let shiftType = shiftTypes.first(where: { $0.id == shiftTypeId }) else {
-            throw CLIError.shiftTypeNotFound(shiftTypeId)
-        }
-        let shift = try await calendar.createShiftEvent(date: date, shiftType: shiftType, notes: notes)
-        let entry = ChangeLogEntry(/* ... */)
-        try await persistence.addChangeLogEntry(entry)
-        return shift
-    }
-}
-```
+In CLI builds all CloudKit operations throw `accountNotAvailable`, which the
+repositories already treat as a benign "offline" warning. iOS app behavior is
+unchanged.
 
 ---
 
 ## EventKit on macOS
 
-1. **Authorization**: On macOS, `EKEventStore.requestFullAccessToEvents()` shows a system dialog. The CLI checks auth status first and provides clear terminal output if denied.
-2. **Shared Calendar**: The iOS app creates a calendar named `"functioncraft.ShiftScheduler"`. The CLI looks for/creates the same calendar, enabling shared shift data.
-3. **No UIKit dependency**: `CalendarService.swift` uses `EventKit` (not `EventKitUI`), so it works on macOS without changes.
+1. **Authorization**: `auth status` reports EventKit state; `auth request` shows the
+   macOS permission dialog. Unauthorized calendar commands fail with a suggestion to
+   run `auth request`.
+2. **Shared Calendar**: The CLI uses the same `functioncraft.ShiftScheduler` calendar
+   as the iOS app (created on iCloud when available), so shifts sync across devices.
 
 ---
 
-## Implementation Phases
+## Implementation Phases — all complete
 
-### Phase 1: Foundation (Package.swift + Core library) ✅ COMPLETE
+- **Phase 1 — Foundation**: Package.swift, shared sources compile, platform guards. ✅
+- **Phase 2 — Skeleton**: CLIController, OutputFormatter, today command, all subcommands registered. ✅
+- **Phase 3 — Data commands**: types/locations/profile/log CRUD with validation. ✅
+- **Phase 4 — Calendar commands**: auth, schedule list/add/edit/delete/switch, undo/redo. ✅
+- **Phase 5 — Polish**: date parsing (`today`, `tomorrow`, `+3d`, `-1w`), JSON errors,
+  exit codes (0/1/64) in root help, examples in every command, `--force` +
+  non-TTY-safe confirmations, `--data-dir`. ✅
+  - *Not shipped*: ANSI color output (`--no-color`) — plain output was chosen for
+    simplicity and clean piping; can be added later if wanted.
 
-**Work:**
-1. Create `Package.swift` with target definitions
-2. Set up `ShiftSchedulerCore` referencing existing files
-3. Resolve platform-specific issues (`#if canImport` guards)
+### Validation (run from the repo root)
 
-**Acceptance Criteria:**
-- [x] `Package.swift` exists with `ShiftSchedulerCore` library and `ShiftSchedulerCLI` executable targets
-- [x] `swift-argument-parser` declared as dependency
-- [x] All domain models accessible from the library target
-- [x] All persistence repositories compile in the library target
-- [x] All service protocols and implementations compile in the library target
-- [x] No unguarded `import SwiftUI` or `import UIKit` in `ShiftSchedulerCore`
-- [x] Minimal `ShiftSchedulerCLI.swift` entry point created
-
-**Validation:**
 ```bash
-swift build --target ShiftSchedulerCore 2>&1 | tail -1
-# Expected: "Build complete!"
+swift build                                        # zero warnings
+swift run shift-scheduler --help                   # full command tree
+DIR=$(mktemp -d)
+swift run shift-scheduler locations add --name "Test" --address "1 Test St" --data-dir $DIR
+swift run shift-scheduler locations list --json --data-dir $DIR
+swift run shift-scheduler types add --title "Day" --symbol D --location Test --start 07:00 --end 15:00 --data-dir $DIR
+swift run shift-scheduler types delete --id Day --data-dir $DIR < /dev/null   # exits 1, no hang
+swift run shift-scheduler types delete --id Day --force --data-dir $DIR
+swift run shift-scheduler auth status --json
 ```
-
----
-
-### Phase 2: CLI Skeleton
-
-**Work:**
-1. Create `CLIController.swift` with service initialization
-2. Create `OutputFormatter.swift` (table + JSON modes)
-3. Implement `today` command as proof-of-concept
-4. Register all subcommand stubs (types, locations, schedule, log, profile, auth)
-
-**Acceptance Criteria:**
-- [ ] `swift build` compiles the full CLI executable with zero errors
-- [ ] `swift run shift-scheduler --help` prints root help with all subcommand names
-- [ ] `swift run shift-scheduler today` executes without crashing
-- [ ] `swift run shift-scheduler today --json` produces valid JSON output
-- [ ] `CLIController` initializes `PersistenceService`, `CalendarService`, and `CurrentDayService`
-- [ ] `OutputFormatter` has both table and JSON rendering paths
-- [ ] All subcommands registered and show `--help` output
-
-**Validation:**
-```bash
-swift run shift-scheduler --help
-swift run shift-scheduler today
-swift run shift-scheduler today --json | jq .
-swift run shift-scheduler types --help
-```
-
----
-
-### Phase 3: Data Management Commands
-
-**Work:**
-1. `types list|add|edit|delete` — full CRUD for shift types
-2. `locations list|add|edit|delete` — full CRUD for locations
-3. `profile show|set` — user profile management
-4. `log list|purge` — change log viewing and cleanup
-
-**Acceptance Criteria:**
-- [ ] **Shift Types CRUD:** list (table + JSON), add (with time or all-day), edit, delete (with confirmation). Persists to `shiftTypes.json`.
-- [ ] **Locations CRUD:** list, add, edit, delete. Persists to `locations.json`.
-- [ ] **Profile:** show (name, retention policy), set display name.
-- [ ] **Change Log:** list with `--limit`, purge with `--older-than` days.
-- [ ] All commands support `--json` flag
-- [ ] Invalid arguments produce clear error messages
-
-**Validation:**
-```bash
-# Round-trip test
-swift run shift-scheduler locations add --name "Test" --address "123 Test St"
-swift run shift-scheduler locations list --json | jq '.[].name'
-swift run shift-scheduler locations delete --id <ID>
-```
-
----
-
-### Phase 4: Calendar Commands
-
-**Work:**
-1. `auth status|request` — check and request EventKit authorization
-2. `schedule list` — list shifts with date range filtering
-3. `schedule add` — create calendar events
-4. `schedule delete` — remove calendar events
-
-**Acceptance Criteria:**
-- [ ] `auth status` reports EventKit authorization state
-- [ ] `auth request` triggers macOS authorization dialog
-- [ ] `schedule list` shows current month by default, supports `--from`/`--to` date range
-- [ ] `schedule add` creates calendar event with optional notes, persists ChangeLogEntry
-- [ ] `schedule delete` removes event with confirmation, persists ChangeLogEntry
-- [ ] Date arguments accept `YYYY-MM-DD`, `today`, `tomorrow`
-- [ ] All commands support `--json` flag
-
-**Validation:**
-```bash
-swift run shift-scheduler auth status
-swift run shift-scheduler schedule list --from 2026-03-01 --to 2026-03-31
-swift run shift-scheduler schedule add --date 2026-04-15 --type <ID>
-swift run shift-scheduler schedule delete --event-id <EVENT-ID>
-swift run shift-scheduler log list --limit 2
-```
-
----
-
-### Phase 5: Polish
-
-**Work:**
-1. ANSI color output for shift symbols and status
-2. Comprehensive error messages and help text
-3. Date parsing utilities (relative dates: `+3d`, `-1w`)
-4. `--data-dir` global option support
-5. `--no-color` flag and auto-detection of non-TTY output
-
-**Acceptance Criteria:**
-- [ ] Terminal output uses colors; disabled when piped or `--no-color` set
-- [ ] Clear error messages with actionable suggestions (e.g., "Run 'shift-scheduler types list'...")
-- [ ] All error messages exit with non-zero status code
-- [ ] Date parsing supports: `YYYY-MM-DD`, `today`, `tomorrow`, `+3d`, `-1w`
-- [ ] `--data-dir` overrides default data directory
-- [ ] Help text is well-formatted with usage examples
-
-**Validation:**
-```bash
-swift run shift-scheduler types list          # Colored output
-swift run shift-scheduler types list | cat    # No ANSI codes
-swift run shift-scheduler schedule list --from today --to +7d
-swift run shift-scheduler --data-dir /tmp/test types list
-swift run shift-scheduler types delete --id "not-a-uuid"  # Clear error, exit 1
-```
-
----
-
-## Key Risks & Mitigations
-
-| Risk | Mitigation |
-|------|-----------|
-| Existing files have `import SwiftUI` or UIKit | Add `#if canImport` guards (done in Phase 1) |
-| CloudKitManager may not compile on macOS CLI | Make it optional or stub for CLI |
-| `@Observable` on Store requires macOS 14+ | CLI doesn't use Store — only services and models |
-| EventKit auth dialog in terminal context | `auth` subcommand handles explicitly |
-| SPM path references to `ShiftScheduler/` sources | Use `path:` parameter in Package.swift targets |

--- a/CLI_USAGE.html
+++ b/CLI_USAGE.html
@@ -1,0 +1,618 @@
+<title>shift-scheduler — CLI Manual</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  :root {
+    --bg: #faf9f6;
+    --surface: #ffffff;
+    --surface-2: #f2efe8;
+    --ink: #1e2126;
+    --ink-soft: #383c42;
+    --muted: #6b7280;
+    --accent: #a85a20;
+    --accent-ink: #ffffff;
+    --agent: #3b5f78;
+    --agent-bg: #eaf1f5;
+    --agent-line: #c3d6e0;
+    --line: #e4e1d9;
+    --line-strong: #d3cfc3;
+    --code-bg: #21242b;
+    --code-ink: #e8e6df;
+    --code-accent: #e6a15c;
+    --code-muted: #8891a0;
+    --danger: #a13d3d;
+    --ok: #3f7a4f;
+    --shadow: 0 1px 2px rgba(30, 33, 38, 0.06), 0 8px 24px -12px rgba(30, 33, 38, 0.12);
+  }
+
+  :root[data-theme="dark"] {
+    --bg: #15171b;
+    --surface: #1b1e23;
+    --surface-2: #20232a;
+    --ink: #e9e7df;
+    --ink-soft: #cbc9c0;
+    --muted: #939aa6;
+    --accent: #e08a45;
+    --accent-ink: #191108;
+    --agent: #8db3cc;
+    --agent-bg: #1c2a33;
+    --agent-line: #2d4453;
+    --line: #2a2d33;
+    --line-strong: #383c44;
+    --code-bg: #0f1114;
+    --code-ink: #e4e2d9;
+    --code-accent: #f0a862;
+    --code-muted: #7c8494;
+    --danger: #d98080;
+    --ok: #7fbf8f;
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 12px 32px -16px rgba(0, 0, 0, 0.6);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #15171b;
+      --surface: #1b1e23;
+      --surface-2: #20232a;
+      --ink: #e9e7df;
+      --ink-soft: #cbc9c0;
+      --muted: #939aa6;
+      --accent: #e08a45;
+      --accent-ink: #191108;
+      --agent: #8db3cc;
+      --agent-bg: #1c2a33;
+      --agent-line: #2d4453;
+      --line: #2a2d33;
+      --line-strong: #383c44;
+      --code-bg: #0f1114;
+      --code-ink: #e4e2d9;
+      --code-accent: #f0a862;
+      --code-muted: #7c8494;
+      --danger: #d98080;
+      --ok: #7fbf8f;
+      --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 12px 32px -16px rgba(0, 0, 0, 0.6);
+    }
+  }
+
+  * { box-sizing: border-box; }
+
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+    * { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
+  }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: -apple-system, "Segoe UI", ui-sans-serif, system-ui, sans-serif;
+    font-size: 16px;
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  h1, h2, h3, h4 {
+    font-family: "Iowan Old Style", "Palatino Linotype", Palatino, "Georgia", serif;
+    font-weight: 600;
+    color: var(--ink);
+    text-wrap: balance;
+    line-height: 1.2;
+  }
+
+  code, pre, kbd, .mono {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", "JetBrains Mono", Menlo, Consolas, monospace;
+  }
+
+  a { color: var(--accent); text-decoration-color: color-mix(in srgb, var(--accent) 45%, transparent); text-underline-offset: 3px; }
+  a:hover { text-decoration-thickness: 2px; }
+  a:focus-visible, button:focus-visible, summary:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    border-radius: 2px;
+  }
+
+  .shell {
+    display: grid;
+    grid-template-columns: 260px minmax(0, 1fr);
+    max-width: 1180px;
+    margin: 0 auto;
+  }
+
+  @media (max-width: 900px) {
+    .shell { grid-template-columns: 1fr; }
+    .toc { display: none; }
+  }
+
+  .toc {
+    position: sticky;
+    top: 0;
+    align-self: start;
+    height: 100vh;
+    overflow-y: auto;
+    padding: 2rem 1.25rem 2rem 1.75rem;
+    border-right: 1px solid var(--line);
+    scrollbar-width: thin;
+  }
+
+  .toc-title {
+    font-family: ui-monospace, monospace;
+    font-size: 0.7rem;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin: 0 0 0.9rem;
+  }
+
+  .toc ol { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.05rem; }
+  .toc a { display: block; padding: 0.32rem 0.5rem; border-radius: 6px; color: var(--ink-soft); font-size: 0.87rem; text-decoration: none; }
+  .toc a:hover { background: var(--surface-2); color: var(--ink); }
+  .toc .sub { padding-left: 1.1rem; font-size: 0.82rem; color: var(--muted); }
+
+  main { padding: 0 2.5rem 6rem; min-width: 0; }
+  @media (max-width: 640px) { main { padding: 0 1.25rem 4rem; } }
+  .content-col { max-width: 43rem; }
+
+  header.hero { padding: 3.2rem 0 2rem; max-width: 43rem; }
+
+  .kicker {
+    display: inline-flex; align-items: center; gap: 0.5rem;
+    font-family: ui-monospace, monospace; font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+    padding: 0.28rem 0.65rem; border-radius: 999px; margin-bottom: 1.1rem;
+  }
+
+  h1.title { font-size: clamp(2.1rem, 4.4vw, 2.9rem); margin: 0 0 0.6rem; }
+  .subtitle { color: var(--ink-soft); font-size: 1.08rem; max-width: 40rem; margin: 0 0 1.6rem; }
+
+  .prompt {
+    display: flex; align-items: center; gap: 0.6rem;
+    background: var(--code-bg); color: var(--code-ink); border-radius: 10px;
+    padding: 0.85rem 1.1rem; font-family: ui-monospace, monospace; font-size: 0.92rem;
+    box-shadow: var(--shadow); overflow-x: auto;
+  }
+  .prompt .sigil { color: var(--code-accent); user-select: none; }
+  .prompt .ver { margin-left: auto; color: var(--code-muted); white-space: nowrap; }
+
+  .meta-row { display: flex; flex-wrap: wrap; gap: 0.5rem 1.4rem; margin-top: 1.1rem; font-size: 0.83rem; color: var(--muted); }
+  .meta-row span { display: inline-flex; align-items: center; gap: 0.4rem; }
+  .meta-row .dot { width: 6px; height: 6px; border-radius: 999px; background: var(--accent); display: inline-block; }
+
+  section { padding-top: 2.6rem; scroll-margin-top: 1.5rem; }
+  h2 { font-size: 1.5rem; padding-bottom: 0.6rem; border-bottom: 1px solid var(--line); margin: 0 0 1.1rem; }
+
+  h3.cmd {
+    font-family: ui-monospace, monospace; font-size: 1.05rem; font-weight: 600;
+    background: var(--surface-2); border: 1px solid var(--line); border-radius: 8px;
+    padding: 0.55rem 0.85rem; margin: 2rem 0 0.9rem; color: var(--ink);
+  }
+
+  h4.subcmd { font-family: ui-monospace, monospace; font-size: 0.95rem; font-weight: 600; color: var(--accent); margin: 1.6rem 0 0.5rem; }
+
+  p { color: var(--ink-soft); }
+  .content-col p, .content-col li { max-width: 42rem; }
+
+  pre {
+    background: var(--code-bg); color: var(--code-ink); border-radius: 10px;
+    padding: 0.95rem 1.15rem; overflow-x: auto; font-size: 0.85rem; line-height: 1.6;
+    margin: 0.9rem 0 1.3rem; box-shadow: var(--shadow);
+  }
+  pre code { background: none; padding: 0; color: inherit; }
+  .content-col pre, .content-col table, .content-col .callout { max-width: 100%; }
+
+  code {
+    background: var(--surface-2); border: 1px solid var(--line); border-radius: 4px;
+    padding: 0.1rem 0.38rem; font-size: 0.87em; color: var(--ink);
+  }
+
+  pre .c1 { color: var(--code-muted); }
+  pre .flag { color: var(--code-accent); }
+
+  .table-wrap { overflow-x: auto; margin: 0.9rem 0 1.4rem; }
+  table { border-collapse: collapse; width: 100%; min-width: 420px; font-size: 0.88rem; }
+  th {
+    text-align: left; font-family: ui-monospace, monospace; font-size: 0.72rem;
+    letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted);
+    padding: 0.5rem 0.9rem; border-bottom: 2px solid var(--line-strong); white-space: nowrap;
+  }
+  td { padding: 0.6rem 0.9rem; border-bottom: 1px solid var(--line); color: var(--ink-soft); vertical-align: top; }
+  td code, td kbd { font-size: 0.85em; }
+  tr:last-child td { border-bottom: none; }
+  td.exit-0 { color: var(--ok); font-weight: 600; }
+  td.exit-1 { color: var(--danger); font-weight: 600; }
+  td.exit-64 { color: var(--muted); font-weight: 600; }
+
+  .callout {
+    border: 1px solid var(--line); border-left: 3px solid var(--accent); background: var(--surface);
+    border-radius: 0 8px 8px 0; padding: 0.9rem 1.1rem; margin: 1rem 0 1.4rem;
+  }
+  .callout p:last-child { margin-bottom: 0; }
+  .callout .label {
+    font-family: ui-monospace, monospace; font-size: 0.72rem; letter-spacing: 0.07em;
+    text-transform: uppercase; color: var(--accent); margin-bottom: 0.35rem; display: block;
+  }
+
+  .agent-block {
+    border: 1px solid var(--agent-line); background: var(--agent-bg); border-radius: 10px;
+    padding: 1.3rem 1.4rem; margin: 1.2rem 0 1.6rem;
+  }
+  .agent-block h4 { margin: 0 0 0.2rem; color: var(--agent); font-family: ui-monospace, monospace; font-size: 0.95rem; }
+  .agent-block ol, .agent-block ul { padding-left: 1.2rem; }
+  .agent-block li { margin-bottom: 0.55rem; color: var(--ink-soft); }
+  .agent-block li:last-child { margin-bottom: 0; }
+  .agent-block code { background: color-mix(in srgb, var(--agent) 12%, var(--surface)); border-color: var(--agent-line); }
+
+  .badge {
+    display: inline-flex; align-items: center; gap: 0.35rem;
+    font-family: ui-monospace, monospace; font-size: 0.7rem; letter-spacing: 0.05em; text-transform: uppercase;
+    padding: 0.18rem 0.55rem; border-radius: 999px; border: 1px solid var(--agent-line);
+    color: var(--agent); background: var(--agent-bg);
+  }
+
+  .ref-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 0.7rem; margin: 1rem 0 1.5rem; }
+  .ref-card { border: 1px solid var(--line); border-radius: 8px; padding: 0.75rem 0.9rem; background: var(--surface); }
+  .ref-card .n { font-family: ui-monospace, monospace; font-weight: 600; color: var(--accent); font-size: 0.85rem; }
+  .ref-card p { margin: 0.25rem 0 0; font-size: 0.85rem; }
+
+  footer {
+    max-width: 43rem; padding: 2.5rem 0 1rem; color: var(--muted); font-size: 0.85rem;
+    border-top: 1px solid var(--line); margin-top: 3rem;
+  }
+</style>
+
+<div class="shell">
+  <nav class="toc" aria-label="Table of contents">
+    <p class="toc-title">On this page</p>
+    <ol>
+      <li><a href="#install">Installation &amp; build</a></li>
+      <li><a href="#quickstart">Quick start</a></li>
+      <li><a href="#globals">Global options</a></li>
+      <li><a href="#exitcodes">Exit codes</a></li>
+      <li><a href="#reference">Command reference</a>
+        <ol>
+          <li class="sub"><a href="#today">today</a></li>
+          <li class="sub"><a href="#schedule">schedule</a></li>
+          <li class="sub"><a href="#types">types</a></li>
+          <li class="sub"><a href="#locations">locations</a></li>
+          <li class="sub"><a href="#log">log</a></li>
+          <li class="sub"><a href="#profile">profile</a></li>
+          <li class="sub"><a href="#auth">auth</a></li>
+          <li class="sub"><a href="#undoredo">undo / redo</a></li>
+        </ol>
+      </li>
+      <li><a href="#dates">Date &amp; time formats</a></li>
+      <li><a href="#refs">Referencing objects</a></li>
+      <li><a href="#agents">For LLM agents</a></li>
+      <li><a href="#humans">For human users</a></li>
+      <li><a href="#datamodel">Data model notes</a></li>
+      <li><a href="#troubleshooting">Troubleshooting</a></li>
+    </ol>
+  </nav>
+
+  <main>
+    <div class="content-col">
+      <header class="hero">
+        <span class="kicker">● CLI Manual</span>
+        <h1 class="title">shift-scheduler</h1>
+        <p class="subtitle">A macOS command-line companion to the ShiftScheduler iOS app — for the person running it by hand, and for the agent running it unattended.</p>
+        <div class="prompt">
+          <span class="sigil">$</span>
+          <span>shift-scheduler --help</span>
+          <span class="ver">v0.1.0</span>
+        </div>
+        <div class="meta-row">
+          <span><span class="dot"></span>swift-argument-parser</span>
+          <span><span class="dot"></span>JSON on <code>--json</code>, human tables by default</span>
+          <span><span class="dot"></span>EventKit + local JSON persistence</span>
+        </div>
+      </header>
+
+      <section id="install">
+        <h2>Installation &amp; build</h2>
+        <pre><code><span class="c1"># from the repo root</span>
+swift build -c release
+.build/release/shift-scheduler --help
+
+<span class="c1"># iterate during development</span>
+swift run shift-scheduler <span class="flag">today</span>
+
+<span class="c1"># optional: put it on PATH</span>
+cp .build/release/shift-scheduler /usr/local/bin/</code></pre>
+      </section>
+
+      <section id="quickstart">
+        <h2>Quick start</h2>
+        <pre><code><span class="c1"># one-time: grant Calendar access</span>
+shift-scheduler auth request
+
+<span class="c1"># set up a location and a shift type</span>
+shift-scheduler locations add <span class="flag">--name</span> "Downtown" <span class="flag">--address</span> "123 Main St"
+shift-scheduler types add <span class="flag">--title</span> "Day Shift" <span class="flag">--symbol</span> D \
+  <span class="flag">--location</span> "Downtown" <span class="flag">--start</span> 07:00 <span class="flag">--end</span> 15:00
+
+<span class="c1"># schedule and inspect</span>
+shift-scheduler schedule add <span class="flag">--date</span> tomorrow <span class="flag">--type</span> "Day Shift"
+shift-scheduler today
+shift-scheduler schedule list <span class="flag">--from</span> today <span class="flag">--to</span> +14d</code></pre>
+      </section>
+
+      <section id="globals">
+        <h2>Global options</h2>
+        <p>Every leaf command accepts these two flags. (<code>schedule</code>, <code>types</code>, <code>locations</code>, <code>log</code>, <code>profile</code>, and <code>auth</code> are group headers — the flags live on their subcommands.)</p>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Flag</th><th>Description</th></tr></thead>
+            <tbody>
+              <tr><td><code>--json</code></td><td>Machine-readable JSON instead of a table/message — on <strong>both</strong> success and error output. Errors go to stderr.</td></tr>
+              <tr><td><code>--data-dir &lt;path&gt;</code></td><td>Override the data directory (default <code>~/Documents/ShiftSchedulerData</code>). Accepts <code>~</code>. Useful for tests, alternate profiles, or sandboxing an agent's writes.</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p>Root-level: <code>shift-scheduler --version</code>, <code>shift-scheduler --help</code>.</p>
+      </section>
+
+      <section id="exitcodes">
+        <h2>Exit codes</h2>
+        <p>Documented in root <code>--help</code> and stable across releases. Scripts and agents should branch on this first, then read stderr for detail.</p>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Code</th><th>Meaning</th></tr></thead>
+            <tbody>
+              <tr><td class="exit-0">0</td><td>Success.</td></tr>
+              <tr><td class="exit-1">1</td><td>Runtime failure — not found, not authorized, I/O error, validation error, cancelled, confirmation required without a TTY.</td></tr>
+              <tr><td class="exit-64">64</td><td>Usage error — unknown command/subcommand, bad or missing arguments.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="reference">
+        <h2>Command reference</h2>
+
+        <article id="today">
+          <h3 class="cmd">shift-scheduler today</h3>
+          <p>Show today's scheduled shifts. Requires calendar authorization. Prints a table, or a "no shifts" message if the day is empty.</p>
+          <pre><code>shift-scheduler today [<span class="flag">--json</span>] [<span class="flag">--data-dir</span> &lt;path&gt;]</code></pre>
+        </article>
+
+        <article id="schedule">
+          <h3 class="cmd">shift-scheduler schedule</h3>
+          <p>Manage scheduled shifts in the calendar. Default subcommand: <code>list</code>.</p>
+
+          <h4 class="subcmd">schedule list</h4>
+          <p>Defaults to the current calendar month. <code>--to</code> is inclusive. Date arguments are validated before the calendar-authorization check, so a bad date reports as a date error, not an auth error.</p>
+          <pre><code>shift-scheduler schedule list [<span class="flag">--from</span> &lt;date&gt;] [<span class="flag">--to</span> &lt;date&gt;] [<span class="flag">--json</span>]
+
+<span class="c1">$ shift-scheduler schedule list --from today --to +14d</span></code></pre>
+
+          <h4 class="subcmd">schedule add</h4>
+          <p>Creates a calendar event and records an undoable change-log entry. Prints the new EventKit identifier — capture it for later <code>edit</code>/<code>delete</code>/<code>switch</code> calls.</p>
+          <pre><code>shift-scheduler schedule add <span class="flag">--date</span> &lt;date&gt; <span class="flag">--type</span> &lt;ref&gt; [<span class="flag">--notes</span> &lt;text&gt;] [<span class="flag">--json</span>]
+
+<span class="c1">$ shift-scheduler schedule add --date 2026-07-15 --type D --notes "Covering for Sam"</span></code></pre>
+
+          <h4 class="subcmd">schedule edit</h4>
+          <p>Replaces a shift's notes (<code>--notes ""</code> clears them). To change the shift type, use <code>switch</code> instead.</p>
+          <pre><code>shift-scheduler schedule edit <span class="flag">--event-id</span> &lt;id&gt; <span class="flag">--notes</span> &lt;text&gt; [<span class="flag">--json</span>]</code></pre>
+
+          <h4 class="subcmd">schedule delete</h4>
+          <p>Deletes the shift and records an undoable change-log entry. Prompts for confirmation unless <code>--force</code> — without a TTY, omitting <code>--force</code> fails fast rather than hanging.</p>
+          <pre><code>shift-scheduler schedule delete <span class="flag">--event-id</span> &lt;id&gt; [<span class="flag">--reason</span> &lt;text&gt;] [<span class="flag">--force</span>] [<span class="flag">--json</span>]</code></pre>
+
+          <h4 class="subcmd">schedule switch</h4>
+          <p>Switches a scheduled shift to a different shift type, recording a before/after snapshot so it can be undone.</p>
+          <pre><code>shift-scheduler schedule switch <span class="flag">--event-id</span> &lt;id&gt; <span class="flag">--to</span> &lt;ref&gt; [<span class="flag">--reason</span> &lt;text&gt;] [<span class="flag">--json</span>]
+
+<span class="c1">$ shift-scheduler schedule switch --event-id &lt;ID&gt; --to N --reason "Traded with Alex"</span></code></pre>
+        </article>
+
+        <article id="types">
+          <h3 class="cmd">shift-scheduler types</h3>
+          <p>Manage shift type templates (title, symbol, time range or all-day, location). Default subcommand: <code>list</code>.</p>
+
+          <h4 class="subcmd">types add</h4>
+          <p>Provide either <code>--all-day</code> or <strong>both</strong> <code>--start</code> and <code>--end</code>. Overnight shifts (end before start) are supported.</p>
+          <pre><code>shift-scheduler types add <span class="flag">--title</span> &lt;text&gt; <span class="flag">--symbol</span> &lt;text&gt; <span class="flag">--location</span> &lt;ref&gt; \
+  [<span class="flag">--description</span> &lt;text&gt;] (<span class="flag">--all-day</span> | <span class="flag">--start</span> &lt;HH:MM&gt; <span class="flag">--end</span> &lt;HH:MM&gt;) [<span class="flag">--json</span>]</code></pre>
+
+          <h4 class="subcmd">types edit</h4>
+          <p>Only the fields you provide change. Existing calendar events using this type cascade-update when calendar access is authorized.</p>
+          <pre><code>shift-scheduler types edit <span class="flag">--id</span> &lt;ref&gt; [<span class="flag">--title</span> …] [<span class="flag">--symbol</span> …] [<span class="flag">--location</span> …] \
+  [(<span class="flag">--all-day</span> | <span class="flag">--start</span> &lt;HH:MM&gt; <span class="flag">--end</span> &lt;HH:MM&gt;)] [<span class="flag">--json</span>]</code></pre>
+
+          <h4 class="subcmd">types delete</h4>
+          <p>Already-scheduled events using this type keep their event but display as "(unknown type)" afterward — deletion does not cascade to the calendar.</p>
+          <pre><code>shift-scheduler types delete <span class="flag">--id</span> &lt;ref&gt; [<span class="flag">--force</span>] [<span class="flag">--json</span>]</code></pre>
+        </article>
+
+        <article id="locations">
+          <h3 class="cmd">shift-scheduler locations</h3>
+          <p>Manage locations. Default subcommand: <code>list</code>.</p>
+
+          <h4 class="subcmd">locations add</h4>
+          <pre><code>shift-scheduler locations add <span class="flag">--name</span> &lt;text&gt; <span class="flag">--address</span> &lt;text&gt; [<span class="flag">--json</span>]</code></pre>
+
+          <h4 class="subcmd">locations edit</h4>
+          <p>Cascades: shift types referencing this location update automatically, and their calendar events update when authorized. Reports both cascade counts.</p>
+          <pre><code>shift-scheduler locations edit <span class="flag">--id</span> &lt;ref&gt; [<span class="flag">--name</span> …] [<span class="flag">--address</span> …] [<span class="flag">--json</span>]</code></pre>
+
+          <h4 class="subcmd">locations delete</h4>
+          <div class="callout">
+            <span class="label">Guardrail</span>
+            <p>Fails with a <code>locationInUse</code> error if any shift type still references the location. Edit or delete those shift types first, or point them elsewhere.</p>
+          </div>
+          <pre><code>shift-scheduler locations delete <span class="flag">--id</span> &lt;ref&gt; [<span class="flag">--force</span>] [<span class="flag">--json</span>]</code></pre>
+        </article>
+
+        <article id="log">
+          <h3 class="cmd">shift-scheduler log</h3>
+          <p>View or purge the shift change log — the audit trail behind <code>undo</code>/<code>redo</code>. Default subcommand: <code>list</code>.</p>
+          <pre><code>shift-scheduler log list [<span class="flag">--limit</span> &lt;n&gt;] [<span class="flag">--json</span>]     <span class="c1"># newest first, default limit 20</span>
+shift-scheduler log purge <span class="flag">--older-than</span> &lt;days&gt; [<span class="flag">--force</span>] [<span class="flag">--json</span>]</code></pre>
+        </article>
+
+        <article id="profile">
+          <h3 class="cmd">shift-scheduler profile</h3>
+          <p>View or update the local user profile. Default subcommand: <code>show</code>. At least one field is required for <code>set</code>.</p>
+          <pre><code>shift-scheduler profile show [<span class="flag">--json</span>]
+shift-scheduler profile set [<span class="flag">--name</span> &lt;text&gt;] [<span class="flag">--retention</span> &lt;policy&gt;] [<span class="flag">--auto-purge</span> &lt;true|false&gt;] [<span class="flag">--json</span>]</code></pre>
+          <p>Valid <code>--retention</code> values: <code>30_days</code>, <code>90_days</code>, <code>6_months</code>, <code>1_year</code>, <code>2_years</code>, <code>forever</code>.</p>
+        </article>
+
+        <article id="auth">
+          <h3 class="cmd">shift-scheduler auth</h3>
+          <p>Check or request calendar (EventKit) authorization. Default subcommand: <code>status</code>.</p>
+          <pre><code>shift-scheduler auth status [<span class="flag">--json</span>]    <span class="c1"># never prompts — reports {"authorized": true|false}</span>
+shift-scheduler auth request [<span class="flag">--json</span>]   <span class="c1"># shows the macOS permission dialog; exits 1 if denied</span></code></pre>
+        </article>
+
+        <article id="undoredo">
+          <h3 class="cmd">shift-scheduler undo / redo</h3>
+          <p>Reverts or re-applies the most recent <code>schedule add</code> / <code>delete</code> / <code>switch</code>, from change-log snapshots. Reports <code>nothingToUndo</code> / <code>nothingToRedo</code> when the stack is empty — checked before calendar authorization, so an empty stack is reported accurately even without calendar access.</p>
+          <pre><code>shift-scheduler undo [<span class="flag">--json</span>]
+shift-scheduler redo [<span class="flag">--json</span>]</code></pre>
+        </article>
+      </section>
+
+      <section id="dates">
+        <h2>Date &amp; time formats</h2>
+        <p><strong>Dates</strong> (<code>--date</code>, <code>--from</code>, <code>--to</code>):</p>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Input</th><th>Meaning</th></tr></thead>
+            <tbody>
+              <tr><td><code>today</code> / <code>tomorrow</code> / <code>yesterday</code></td><td>Relative to the current day.</td></tr>
+              <tr><td><code>+Nd</code> / <code>-Nd</code></td><td>N days from today, e.g. <code>+14d</code>, <code>-7d</code>.</td></tr>
+              <tr><td><code>+Nw</code> / <code>-Nw</code></td><td>N weeks from today, e.g. <code>+2w</code>.</td></tr>
+              <tr><td><code>YYYY-MM-DD</code></td><td>Absolute date, e.g. <code>2026-07-15</code>.</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p><strong>Times</strong> (<code>--start</code>, <code>--end</code>): 24-hour <code>HH:MM</code>, e.g. <code>07:00</code>, <code>22:30</code>. Overnight ranges (end &lt; start) are valid.</p>
+      </section>
+
+      <section id="refs">
+        <h2>Referencing objects</h2>
+        <p>Anywhere a command takes a shift-type or location reference (<code>--type</code>, <code>--to</code>, <code>--location</code>, or <code>--id</code> on <code>types</code>/<code>locations</code>), pass:</p>
+        <div class="ref-grid">
+          <div class="ref-card"><span class="n">UUID</span><p>Always unambiguous — preferred for scripts and agents.</p></div>
+          <div class="ref-card"><span class="n">Title / name</span><p>Case-insensitive; shift types by title, locations by name.</p></div>
+          <div class="ref-card"><span class="n">Symbol</span><p>Shift types only, case-insensitive (e.g. <code>D</code>, <code>N</code>).</p></div>
+        </div>
+        <p>A match on more than one object fails with an <code>ambiguous</code> error listing the candidates — re-run with the UUID. Scheduled shifts are always referenced by EventKit <code>--event-id</code>, obtained from <code>schedule list</code> or the output of <code>schedule add</code>.</p>
+      </section>
+
+      <section id="agents">
+        <h2>For LLM agents <span class="badge">machine contract</span></h2>
+        <p>Rely on this contract rather than parsing human-readable text.</p>
+
+        <div class="agent-block">
+          <h4>01 · Always pass --json</h4>
+          <p>Human table output isn't a stable format; JSON field names are.</p>
+        </div>
+
+        <div class="agent-block">
+          <h4>02 · Error shape (stderr)</h4>
+          <pre><code>{
+  "error": {
+    "message": "No shift type matches 'Nite Shift'",
+    "suggestion": "Run 'shift-scheduler types list' to see available shift types. …"
+  }
+}</code></pre>
+          <p style="margin-top:0.6rem"><code>suggestion</code> appears when there's an actionable next step. Check the exit code first — <code>0</code> means stdout holds the result; nonzero means stderr holds the error.</p>
+        </div>
+
+        <div class="agent-block">
+          <h4>03 · Destructive commands never hang</h4>
+          <p><code>schedule delete</code>, <code>types delete</code>, <code>locations delete</code>, and <code>log purge</code> only prompt when stdin is a TTY. Non-interactively, the prompt is skipped and the command fails immediately with <code>confirmationRequired</code> (exit 1) unless <code>--force</code> is passed. Always pass <code>--force</code> from an agent, and gate that decision in your own logic.</p>
+        </div>
+
+        <div class="agent-block">
+          <h4>04 · auth request needs a human</h4>
+          <p>It shows the native macOS permission dialog — there's no headless path to grant EventKit access. Call <code>auth status --json</code> first; if <code>authorized</code> is <code>false</code>, surface that to a human instead of invoking <code>auth request</code> unattended.</p>
+        </div>
+
+        <div class="agent-block">
+          <h4>05 · Prefer UUIDs</h4>
+          <p>Avoid <code>ambiguous</code> errors in generated commands. Get UUIDs from <code>id</code> in <code>types list --json</code> / <code>locations list --json</code>; get event IDs from <code>eventId</code> in <code>schedule list --json</code> / <code>schedule add --json</code>.</p>
+        </div>
+
+        <div class="agent-block">
+          <h4>06 · No idempotency on add</h4>
+          <p><code>schedule add</code> always creates a new event — retrying a successful call duplicates the shift. Check <code>schedule list</code> first if you're unsure whether it already exists.</p>
+        </div>
+
+        <div class="agent-block">
+          <h4>07 · --data-dir sandboxes reference data only</h4>
+          <p>It does <strong>not</strong> sandbox calendar writes — those always go to the shared <code>functioncraft.ShiftScheduler</code> calendar. There's no <code>--dry-run</code> for calendar-mutating commands; confirm authorization and review <code>schedule list</code> before mutating if you need a rehearsal.</p>
+        </div>
+
+        <div class="agent-block">
+          <h4>08 · undo/redo is one global, shared stack</h4>
+          <p>Not scoped per session or per actor. Undoing after another actor (the iOS app, another script) has made changes may not do what you expect — prefer targeted <code>edit</code>/<code>switch</code>/<code>delete</code> calls with explicit event IDs in multi-actor environments.</p>
+        </div>
+
+        <h3 style="font-family:ui-monospace,monospace;font-size:1rem;margin-top:2rem">Stable JSON fields</h3>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>DTO</th><th>Fields</th></tr></thead>
+            <tbody>
+              <tr><td><code>LocationDTO</code></td><td><code>id, name, address</code></td></tr>
+              <tr><td><code>ShiftTypeDTO</code></td><td><code>id, symbol, title, description, allDay, startTime, endTime, location</code></td></tr>
+              <tr><td><code>ShiftDTO</code></td><td><code>eventId, date, endDate, shiftType, notes, sickDay, sickReason</code></td></tr>
+              <tr><td><code>ChangeLogEntryDTO</code></td><td><code>id, timestamp, user, changeType, shiftDate, from, to, reason</code></td></tr>
+              <tr><td><code>ProfileDTO</code></td><td><code>userId, displayName, retentionPolicy, autoPurgeEnabled, lastPurgeDate</code></td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p>Dates are <code>YYYY-MM-DD</code>; timestamps are ISO 8601.</p>
+
+        <h3 style="font-family:ui-monospace,monospace;font-size:1rem;margin-top:2rem">Minimal agent recipe</h3>
+        <pre><code>shift-scheduler auth status --json                            <span class="c1"># confirm access first</span>
+shift-scheduler types list --json                              <span class="c1"># get type UUIDs</span>
+shift-scheduler locations list --json                           <span class="c1"># get location UUIDs</span>
+shift-scheduler schedule list --from today --to +7d --json     <span class="c1"># check current state</span>
+shift-scheduler schedule add --date 2026-07-15 --type &lt;UUID&gt; --json   <span class="c1"># mutate</span></code></pre>
+      </section>
+
+      <section id="humans">
+        <h2>For human users</h2>
+        <ul>
+          <li>Run any command with <code>--help</code> for its flags, an abstract, and worked examples — every leaf command has an <code>EXAMPLES:</code> section, e.g. <code>shift-scheduler schedule switch --help</code>.</li>
+          <li>Omit <code>--json</code> for readable, aligned tables.</li>
+          <li>Destructive commands prompt <code>[y/N]</code> interactively — no need to remember <code>--force</code> unless you're scripting.</li>
+          <li>Made a mistake? <code>shift-scheduler undo</code> reverts the last add/delete/switch; <code>redo</code> re-applies it.</li>
+          <li>The calendar is named <strong>functioncraft.ShiftScheduler</strong>, visible in Calendar.app and the iOS app once access is granted and iCloud sync catches up.</li>
+          <li><code>--data-dir</code> is mainly for testing — leave it at the default day-to-day so the CLI and iOS app see the same reference data.</li>
+        </ul>
+      </section>
+
+      <section id="datamodel">
+        <h2>Data model notes</h2>
+        <p><strong>Reference data</strong> (shift types, locations, profile, change log) is local JSON on the machine running the CLI, at <code>~/Documents/ShiftSchedulerData/</code> by default. It syncs through CloudKit only where entitlements allow (the iOS app) — an unbundled CLI binary has none, so CloudKit sync silently no-ops there (treated internally as a benign "offline" condition), and reference data stays local to that machine's <code>--data-dir</code>.</p>
+        <p><strong>Scheduled shifts</strong> live in EventKit, in the shared <code>functioncraft.ShiftScheduler</code> calendar. This does sync across devices via iCloud, independent of the CloudKit path above — it's the actual mechanism by which CLI-created shifts appear in the iOS app.</p>
+        <p><strong>Undo/redo</strong> replays from <code>ChangeLogEntry</code> snapshots (no stored EventKit identifiers); shifts are re-located by date + shift-type ID when reverting or reapplying.</p>
+      </section>
+
+      <section id="troubleshooting">
+        <h2>Troubleshooting</h2>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Symptom</th><th>Cause</th><th>Fix</th></tr></thead>
+            <tbody>
+              <tr><td><code>Calendar access is not authorized</code></td><td>EventKit permission not granted</td><td><code>auth request</code> and grant it in the dialog</td></tr>
+              <tr><td><code>Confirmation required: …</code> in a script</td><td>No TTY, <code>--force</code> omitted</td><td>Add <code>--force</code></td></tr>
+              <tr><td><code>'X' matches multiple shift types:</code></td><td>Ambiguous title/symbol</td><td>Re-run using the UUID (<code>types list --json</code>)</td></tr>
+              <tr><td><code>Location 'X' is used by shift type(s): …</code></td><td>Deleting a referenced location</td><td>Edit/delete those shift types first, or use another location</td></tr>
+              <tr><td><code>Cannot parse date 'X'</code></td><td>Unsupported format</td><td>Use <code>YYYY-MM-DD</code>, <code>today</code>/<code>tomorrow</code>, or <code>+Nd</code>/<code>-Nw</code></td></tr>
+              <tr><td>CLI and iOS app show different data</td><td>Different <code>--data-dir</code>, or CloudKit unavailable to the CLI</td><td>Confirm the same data directory / calendar; remember reference-data CloudKit sync is iOS-only</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <footer>
+        shift-scheduler v0.1.0 · CLI companion to the ShiftScheduler iOS app · source of truth: <code>CLI_USAGE.md</code> in the repository root
+      </footer>
+    </div>
+  </main>
+</div>

--- a/CLI_USAGE.md
+++ b/CLI_USAGE.md
@@ -1,0 +1,608 @@
+# shift-scheduler CLI — Usage Manual
+
+A macOS command-line interface for ShiftScheduler. It reads and writes the
+same data the iOS app uses — shift types, locations, profile, and change log
+as JSON in `~/Documents/ShiftSchedulerData/` (override with `--data-dir`),
+plus scheduled shifts in the shared `functioncraft.ShiftScheduler` EventKit
+calendar, which syncs with the iOS app via iCloud when available.
+
+This manual covers usage for **human operators** and for **LLM agents**
+driving the tool programmatically. Read the "For LLM Agents" section before
+scripting against this CLI — it documents the machine-readable contract
+(`--json`, exit codes, error shape) you should rely on instead of parsing
+human-readable text.
+
+Binary name: `shift-scheduler`. Version: `0.1.0`.
+
+---
+
+## Table of Contents
+
+1. [Installation & Build](#installation--build)
+2. [Quick Start](#quick-start)
+3. [Global Options](#global-options)
+4. [Exit Codes](#exit-codes)
+5. [Command Reference](#command-reference)
+   - [today](#today)
+   - [schedule](#schedule)
+   - [types](#types)
+   - [locations](#locations)
+   - [log](#log)
+   - [profile](#profile)
+   - [auth](#auth)
+   - [undo / redo](#undo--redo)
+6. [Date & Time Formats](#date--time-formats)
+7. [Referencing Objects (types & locations)](#referencing-objects-types--locations)
+8. [For LLM Agents](#for-llm-agents)
+9. [For Human Users](#for-human-users)
+10. [Data Model Notes](#data-model-notes)
+11. [Troubleshooting](#troubleshooting)
+
+---
+
+## Installation & Build
+
+```bash
+git clone <repo>
+cd ShiftScheduler
+swift build -c release
+.build/release/shift-scheduler --help
+```
+
+For iterative development, `swift run shift-scheduler <args>` builds and runs
+in one step (debug configuration).
+
+There is no separate install step; copy the built binary onto your `PATH` if
+you want a bare `shift-scheduler` command, e.g.:
+
+```bash
+cp .build/release/shift-scheduler /usr/local/bin/
+```
+
+---
+
+## Quick Start
+
+```bash
+# One-time: grant Calendar access
+shift-scheduler auth request
+
+# Set up a location and a shift type
+shift-scheduler locations add --name "Downtown" --address "123 Main St"
+shift-scheduler types add --title "Day Shift" --symbol D \
+  --location "Downtown" --start 07:00 --end 15:00
+
+# Schedule and inspect
+shift-scheduler schedule add --date tomorrow --type "Day Shift"
+shift-scheduler today
+shift-scheduler schedule list --from today --to +14d
+```
+
+---
+
+## Global Options
+
+Every leaf command (the actual executable subcommands, not `schedule`/`types`
+group headers) accepts:
+
+| Flag | Description |
+|---|---|
+| `--json` | Emit machine-readable JSON instead of a human-readable table/message. Applies to **both success and error** output (errors go to stderr; see [For LLM Agents](#for-llm-agents)). |
+| `--data-dir <path>` | Override the data directory (default `~/Documents/ShiftSchedulerData`). Accepts `~` expansion. Useful for tests, multiple profiles, or sandboxing an agent's writes. |
+
+Root-level flags (on `shift-scheduler` itself): `--version`, `--help` / `-h`.
+
+---
+
+## Exit Codes
+
+Documented in `shift-scheduler --help` and stable across releases:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success. |
+| `1` | Runtime failure — not found, not authorized, I/O error, validation error, user cancelled, confirmation required without a TTY. |
+| `64` | Usage error — unknown command/subcommand, bad or missing arguments (standard `sysexits.h` `EX_USAGE`, provided by swift-argument-parser). |
+
+Scripts and agents should branch on exit code first, then inspect stderr
+(`--json` or plain text) for detail.
+
+---
+
+## Command Reference
+
+### `today`
+
+Show today's scheduled shifts.
+
+```
+shift-scheduler today [--json] [--data-dir <path>]
+```
+
+Requires calendar authorization (see [`auth`](#auth)). Prints a table of
+today's shifts, or "No shifts scheduled for today (...)" if none.
+
+---
+
+### `schedule`
+
+Manage scheduled shifts in the calendar. Default subcommand: `list`.
+
+#### `schedule list`
+
+```
+shift-scheduler schedule list [--from <date>] [--to <date>] [--json]
+```
+
+- Defaults to the **current calendar month** if `--from`/`--to` are omitted.
+- `--to` is **inclusive**.
+- Dates accept the formats in [Date & Time Formats](#date--time-formats).
+- Date arguments are validated *before* the calendar-authorization check, so
+  a bad `--from`/`--to` value reports as a date error, not an auth error.
+
+```bash
+shift-scheduler schedule list
+shift-scheduler schedule list --from today --to +14d
+shift-scheduler schedule list --from 2026-07-01 --to 2026-07-31 --json
+```
+
+#### `schedule add`
+
+```
+shift-scheduler schedule add --date <date> --type <ref> [--notes <text>] [--json]
+```
+
+Creates a calendar event for the given shift type on the given date and
+records a change-log entry (undoable). Prints the new event's EventKit
+identifier — capture this for later `edit`/`delete`/`switch` calls.
+
+```bash
+shift-scheduler schedule add --date tomorrow --type "Day Shift"
+shift-scheduler schedule add --date 2026-07-15 --type D --notes "Covering for Sam"
+```
+
+#### `schedule edit`
+
+```
+shift-scheduler schedule edit --event-id <id> --notes <text> [--json]
+```
+
+Replaces a shift's notes (pass `--notes ""` to clear them). To change the
+shift *type* instead, use `schedule switch`.
+
+```bash
+shift-scheduler schedule edit --event-id <ID> --notes "Trade with Alex"
+shift-scheduler schedule edit --event-id <ID> --notes ""
+```
+
+#### `schedule delete`
+
+```
+shift-scheduler schedule delete --event-id <id> [--reason <text>] [--force] [--json]
+```
+
+Deletes the shift and records a change-log entry (undoable). Prompts for
+confirmation unless `--force` is given; without a TTY, omitting `--force`
+fails fast with exit `1` rather than hanging (see [For LLM Agents](#for-llm-agents)).
+
+```bash
+shift-scheduler schedule delete --event-id <ID>
+shift-scheduler schedule delete --event-id <ID> --force --reason "Shift cancelled"
+```
+
+#### `schedule switch`
+
+```
+shift-scheduler schedule switch --event-id <id> --to <ref> [--reason <text>] [--json]
+```
+
+Switches a scheduled shift to a different shift type, recording a
+before/after snapshot in the change log so it can be undone.
+
+```bash
+shift-scheduler schedule switch --event-id <ID> --to "Night Shift"
+shift-scheduler schedule switch --event-id <ID> --to N --reason "Traded with Alex"
+```
+
+---
+
+### `types`
+
+Manage shift type templates (title, symbol, time range or all-day, location).
+Default subcommand: `list`.
+
+#### `types list`
+
+```
+shift-scheduler types list [--json]
+```
+
+#### `types add`
+
+```
+shift-scheduler types add --title <text> --symbol <text> --location <ref> \
+  [--description <text>] (--all-day | --start <HH:MM> --end <HH:MM>) [--json]
+```
+
+Provide either `--all-day` or **both** `--start` and `--end`. Overnight
+shifts (end time before start time) are supported.
+
+```bash
+shift-scheduler types add --title "Day Shift" --symbol D --location "Downtown" --start 07:00 --end 15:00
+shift-scheduler types add --title "On Call" --symbol OC --location "Downtown" --all-day
+```
+
+#### `types edit`
+
+```
+shift-scheduler types edit --id <ref> [--title <text>] [--symbol <text>] \
+  [--description <text>] [--location <ref>] \
+  (--all-day | --start <HH:MM> --end <HH:MM>) [--json]
+```
+
+Only the fields you provide change. Existing calendar events using this type
+are updated in place when calendar access is authorized (reports how many
+were cascaded).
+
+```bash
+shift-scheduler types edit --id "Day Shift" --symbol DS
+shift-scheduler types edit --id <UUID> --start 08:00 --end 16:00
+```
+
+#### `types delete`
+
+```
+shift-scheduler types delete --id <ref> [--force] [--json]
+```
+
+Already-scheduled events using this type keep their event but display as
+"(unknown type)" afterward — deletion does not cascade to the calendar.
+
+```bash
+shift-scheduler types delete --id "Day Shift"
+shift-scheduler types delete --id <UUID> --force
+```
+
+---
+
+### `locations`
+
+Manage locations. Default subcommand: `list`.
+
+#### `locations list`
+
+```
+shift-scheduler locations list [--json]
+```
+
+#### `locations add`
+
+```
+shift-scheduler locations add --name <text> --address <text> [--json]
+```
+
+#### `locations edit`
+
+```
+shift-scheduler locations edit --id <ref> [--name <text>] [--address <text>] [--json]
+```
+
+Cascades: shift types referencing this location are updated automatically,
+and existing calendar events using those types are updated when calendar
+access is authorized. Reports both cascade counts.
+
+```bash
+shift-scheduler locations edit --id "Downtown" --address "456 Oak Ave"
+```
+
+#### `locations delete`
+
+```
+shift-scheduler locations delete --id <ref> [--force] [--json]
+```
+
+**Fails with a `locationInUse` error if any shift type still references the
+location** — delete/edit those shift types first, or point them elsewhere.
+
+```bash
+shift-scheduler locations delete --id "Downtown"
+shift-scheduler locations delete --id <UUID> --force
+```
+
+---
+
+### `log`
+
+View or purge the shift change log (the audit trail behind `undo`/`redo`).
+Default subcommand: `list`.
+
+#### `log list`
+
+```
+shift-scheduler log list [--limit <n>] [--json]
+```
+
+Newest first. `--limit` defaults to 20 and must be positive.
+
+```bash
+shift-scheduler log list
+shift-scheduler log list --limit 10 --json
+```
+
+#### `log purge`
+
+```
+shift-scheduler log purge --older-than <days> [--force] [--json]
+```
+
+Deletes change-log entries older than the given number of days. `--older-than`
+must be a positive integer.
+
+```bash
+shift-scheduler log purge --older-than 90
+shift-scheduler log purge --older-than 30 --force
+```
+
+---
+
+### `profile`
+
+View or update the local user profile (display name, change-log retention
+policy, auto-purge). Default subcommand: `show`.
+
+#### `profile show`
+
+```
+shift-scheduler profile show [--json]
+```
+
+#### `profile set`
+
+```
+shift-scheduler profile set [--name <text>] [--retention <policy>] [--auto-purge <true|false>] [--json]
+```
+
+At least one field must be provided. Valid `--retention` values:
+`30_days`, `90_days`, `6_months`, `1_year`, `2_years`, `forever`.
+
+```bash
+shift-scheduler profile set --name "Alex"
+shift-scheduler profile set --retention 90_days --auto-purge true
+```
+
+---
+
+### `auth`
+
+Check or request calendar (EventKit) authorization. Default subcommand:
+`status`.
+
+#### `auth status`
+
+```
+shift-scheduler auth status [--json]
+```
+
+Reports `{"authorized": true|false}` in JSON mode. Never prompts.
+
+#### `auth request`
+
+```
+shift-scheduler auth request [--json]
+```
+
+Triggers the macOS system permission dialog (interactive; there is no
+non-interactive way to grant Calendar access — see
+[For LLM Agents](#for-llm-agents)). Exits `1` if access is denied.
+
+---
+
+### `undo` / `redo`
+
+```
+shift-scheduler undo [--json]
+shift-scheduler redo [--json]
+```
+
+Undo/redo the most recent `schedule add` / `schedule delete` /
+`schedule switch` operation, using snapshots recorded in the change log.
+`undo` moves the operation onto the redo stack; `redo` re-applies it. Both
+report `nothingToUndo` / `nothingToRedo` (exit `1`) when their stack is
+empty — this check happens *before* the calendar-authorization check, so an
+empty stack is reported accurately even without calendar access.
+
+```bash
+shift-scheduler undo
+shift-scheduler redo --json
+```
+
+---
+
+## Date & Time Formats
+
+**Dates** (`--date`, `--from`, `--to`, `--older-than` is a day count, not a
+date):
+
+| Input | Meaning |
+|---|---|
+| `today` / `tomorrow` / `yesterday` | Relative to the current day. |
+| `+Nd` / `-Nd` | N days from today, e.g. `+14d`, `-7d`. |
+| `+Nw` / `-Nw` | N weeks from today, e.g. `+2w`. |
+| `YYYY-MM-DD` | Absolute date, e.g. `2026-07-15`. |
+
+All dates are normalized to start-of-day in the local calendar.
+
+**Times** (`--start`, `--end`): 24-hour `HH:MM`, e.g. `07:00`, `22:30`.
+Overnight ranges (end < start) are valid and represent a shift crossing
+midnight.
+
+Invalid input raises `invalidDate` / `invalidTime` with a suggestion listing
+the accepted formats — see [CLIError](#for-llm-agents) below.
+
+---
+
+## Referencing Objects (types & locations)
+
+Anywhere a command takes a shift-type or location reference (`--type`,
+`--to`, `--location`, `--id` on `types`/`locations` commands), you may pass:
+
+1. A **UUID** (unambiguous, preferred for scripts/agents).
+2. A **title** (shift types) or **name** (locations), case-insensitive.
+3. A **symbol** (shift types only), case-insensitive.
+
+If a title/symbol matches more than one object, the command fails with an
+`ambiguous` error listing the candidates — re-run with the UUID to
+disambiguate. Scheduled shifts (`--event-id`) are always referenced by their
+EventKit event identifier, obtained from `schedule list` or the output of
+`schedule add`.
+
+---
+
+## For LLM Agents
+
+This CLI is designed to be driven programmatically. Rely on the following
+contract rather than parsing human-readable text:
+
+1. **Always pass `--json`.** Every leaf command supports it, on both the
+   success path and the error path. Human-readable table output is not a
+   stable format and may change; JSON field names are stable.
+
+2. **Error shape.** On failure, JSON mode writes to **stderr**:
+   ```json
+   {
+     "error": {
+       "message": "No shift type matches 'Nite Shift'",
+       "suggestion": "Run 'shift-scheduler types list' to see available shift types. You can reference a type by UUID, title, or symbol."
+     }
+   }
+   ```
+   `suggestion` is present when there's an actionable next step (not always).
+   Non-JSON mode writes `Error: <message>` and, if present, the suggestion
+   on the next line, also to stderr. Check the exit code first — 0 always
+   means stdout holds the result payload; nonzero always means stderr holds
+   the error.
+
+3. **Exit codes**: `0` success, `1` runtime failure, `64` usage error. See
+   [Exit Codes](#exit-codes).
+
+4. **Destructive commands never hang waiting for input.** `schedule delete`,
+   `types delete`, `locations delete`, and `log purge` prompt for
+   confirmation only when stdin is a TTY. In a non-interactive context
+   (agent, script, CI), the confirmation prompt is skipped and the command
+   **fails immediately** with a `confirmationRequired` error (exit `1`)
+   unless `--force` is passed. Always pass `--force` when calling these from
+   an agent, and gate the decision to do so in your own logic (the CLI will
+   not ask twice).
+
+5. **`auth request` requires a human at the keyboard.** It shows the native
+   macOS permission dialog — there is no headless/non-interactive way to
+   grant EventKit access. An agent should call `auth status --json` first
+   and, if `authorized` is `false`, surface that to a human rather than
+   attempting `auth request` unattended. All calendar-touching commands
+   (`today`, `schedule *`, `undo`, `redo`) will fail with
+   `calendarNotAuthorized` until access is granted.
+
+6. **Object references**: prefer UUIDs over titles/names/symbols in
+   generated commands to avoid `ambiguous` errors. Obtain UUIDs from the
+   `id` field of `types list --json` / `locations list --json`, and event
+   IDs from the `eventId` field of `schedule list --json` /
+   `schedule add --json`.
+
+7. **Idempotency / retries**: `schedule add` always creates a new event —
+   retrying a successful `add` creates a duplicate shift. Check
+   `schedule list --from <date> --to <date> --json` first if you're unsure
+   whether a shift already exists before adding one.
+
+8. **`--data-dir` for sandboxing**: point an agent's reference-data writes
+   (`types`, `locations`, `profile`, `log`) at a scratch directory with
+   `--data-dir` to avoid touching the user's real data while testing a
+   workflow. Note this does **not** sandbox calendar writes — those always
+   go to the shared `functioncraft.ShiftScheduler` EventKit calendar. There
+   is currently no `--dry-run` flag for calendar-mutating commands
+   (`schedule add/edit/delete/switch`); an agent that needs a rehearsal
+   should call `auth status --json` to confirm authorization state and
+   review `schedule list` before mutating.
+
+9. **`undo`/`redo` are single-step and shared state.** They operate on one
+   global stack, not scoped to a session or an agent — undoing after
+   another actor (the iOS app, another script) has made changes may not
+   produce the effect you expect. Prefer targeted `schedule edit`/`switch`/
+   `delete` calls with explicit event IDs over relying on `undo` in
+   multi-actor environments.
+
+10. **Stable JSON field names to depend on**: see the DTOs below. These are
+    hand-written output shapes, decoupled from internal model encodings, and
+    are the recommended integration surface.
+
+    - `LocationDTO`: `id, name, address`
+    - `ShiftTypeDTO`: `id, symbol, title, description, allDay, startTime, endTime, location`
+    - `ShiftDTO`: `eventId, date, endDate, shiftType, notes, sickDay, sickReason`
+    - `ChangeLogEntryDTO`: `id, timestamp, user, changeType, shiftDate, from, to, reason`
+    - `ProfileDTO`: `userId, displayName, retentionPolicy, autoPurgeEnabled, lastPurgeDate`
+
+    Dates are `YYYY-MM-DD`; timestamps are ISO 8601.
+
+**Minimal agent recipe:**
+
+```bash
+shift-scheduler auth status --json                      # confirm access first
+shift-scheduler types list --json                       # get type UUIDs
+shift-scheduler locations list --json                    # get location UUIDs
+shift-scheduler schedule list --from today --to +7d --json   # check current state
+shift-scheduler schedule add --date 2026-07-15 --type <UUID> --json   # mutate
+```
+
+Always check the process exit code before trusting stdout.
+
+---
+
+## For Human Users
+
+- Run any command with `--help` to see its flags, an abstract, and worked
+  examples — every leaf command has an `EXAMPLES:` section in its
+  `discussion`, e.g. `shift-scheduler schedule switch --help`.
+- Omit `--json` for readable, aligned tables.
+- Destructive commands (`schedule delete`, `types delete`,
+  `locations delete`, `log purge`) prompt `[y/N]` when run interactively —
+  no need to remember `--force` unless you're scripting.
+- Made a mistake? `shift-scheduler undo` reverts the last add/delete/switch;
+  `shift-scheduler redo` re-applies it if you change your mind.
+- The calendar this CLI writes to is named **functioncraft.ShiftScheduler**
+  and is visible in Calendar.app / the iOS app once calendar access is
+  granted (`shift-scheduler auth request`) and iCloud sync has caught up.
+- `--data-dir` is mainly useful for testing; day-to-day use should leave it
+  at the default (`~/Documents/ShiftSchedulerData`) so the CLI and iOS app
+  see the same reference data.
+
+---
+
+## Data Model Notes
+
+- **Reference data** (shift types, locations, profile, change log) is local
+  JSON on the machine running the CLI, at `~/Documents/ShiftSchedulerData/`
+  by default. It is *not* automatically shared with an iOS device's sandbox;
+  it syncs through CloudKit only where entitlements allow (the iOS app).
+  Running the CLI on a Mac without CloudKit entitlements (the normal case
+  for an unbundled command-line binary) means CloudKit sync silently
+  no-ops — treated internally as a benign "offline" condition — and
+  reference data stays local to that machine's `--data-dir`.
+- **Scheduled shifts** live in EventKit, in the shared
+  `functioncraft.ShiftScheduler` calendar. This *does* sync across devices
+  via iCloud, independent of the CloudKit reference-data path above — this
+  is the actual mechanism by which CLI-created shifts appear in the iOS app.
+- **Undo/redo** replays from `ChangeLogEntry` snapshots (no stored EventKit
+  identifiers); shifts are re-located by date + shift-type ID when
+  reverting/reapplying.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Calendar access is not authorized` | EventKit permission not granted | `shift-scheduler auth request` (interactive; grant it in the macOS dialog) |
+| `Confirmation required: ...` on a delete/purge in a script | No TTY, `--force` omitted | Add `--force` |
+| `'X' matches multiple shift types:` | Ambiguous title/symbol reference | Re-run using the UUID (`types list --json`) |
+| `Location 'X' is used by shift type(s): ...` | Deleting a location still referenced by a type | Edit/delete those shift types first, or use a different location |
+| `Cannot parse date 'X'` | Unsupported date format | Use `YYYY-MM-DD`, `today`/`tomorrow`/`yesterday`, or `+Nd`/`-Nw` |
+| CLI and iOS app show different reference data | Different `--data-dir`, or CloudKit sync unavailable to the CLI | Confirm both are using the same data directory / calendar; remember reference-data CloudKit sync is iOS-only (see [Data Model Notes](#data-model-notes)) |

--- a/Package.swift
+++ b/Package.swift
@@ -7,10 +7,6 @@ let package = Package(
         .macOS(.v14)
     ],
     products: [
-        .library(
-            name: "ShiftSchedulerCore",
-            targets: ["ShiftSchedulerCore"]
-        ),
         .executable(
             name: "shift-scheduler",
             targets: ["ShiftSchedulerCLI"]
@@ -23,42 +19,45 @@ let package = Package(
         )
     ],
     targets: [
-        // Core library: domain models, persistence, repositories, services
-        // References existing iOS source files directly via path
-        .target(
-            name: "ShiftSchedulerCore",
-            dependencies: [],
-            path: "ShiftScheduler",
+        // Single-module executable: compiles the iOS app's domain, persistence,
+        // and service sources together with the CLI sources. The app code has no
+        // `public` API surface, so a separate library module would require
+        // publicizing dozens of types; one module keeps the app sources unchanged.
+        .executableTarget(
+            name: "ShiftSchedulerCLI",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ],
+            path: ".",
+            exclude: [
+                // Test doubles must not ship in the executable
+                "ShiftScheduler/Redux/Services/Mocks",
+                // App-level DI container; references the mocks and is unused by the CLI
+                "ShiftScheduler/Redux/Services/ServiceContainer.swift"
+            ],
             sources: [
                 // Domain models
-                "Models",
+                "ShiftScheduler/Models",
                 // Domain value objects
-                "Domain",
+                "ShiftScheduler/Domain",
                 // Persistence repositories
-                "Persistence",
+                "ShiftScheduler/Persistence",
                 // Repository protocols
-                "Repositories",
+                "ShiftScheduler/Repositories",
                 // Foundation protocols (DateProviderProtocol, UserDefaultsProtocol)
-                "Protocols",
+                "ShiftScheduler/Protocols",
                 // Services: TimeChangeService (guards UIKit via #if canImport)
-                "Services",
+                "ShiftScheduler/Services",
                 // Redux services layer (protocols + implementations)
-                "Redux/Services",
+                "ShiftScheduler/Redux/Services",
                 // Redux error types (ScheduleError used by services)
-                "Redux/Errors"
+                "ShiftScheduler/Redux/Errors",
+                // CLI commands and utilities
+                "Sources/ShiftSchedulerCLI"
             ],
             swiftSettings: [
                 .define("SWIFT_PACKAGE")
             ]
-        ),
-        // CLI executable
-        .executableTarget(
-            name: "ShiftSchedulerCLI",
-            dependencies: [
-                "ShiftSchedulerCore",
-                .product(name: "ArgumentParser", package: "swift-argument-parser")
-            ],
-            path: "Sources/ShiftSchedulerCLI"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,64 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ShiftScheduler",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .library(
+            name: "ShiftSchedulerCore",
+            targets: ["ShiftSchedulerCore"]
+        ),
+        .executable(
+            name: "shift-scheduler",
+            targets: ["ShiftSchedulerCLI"]
+        )
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/apple/swift-argument-parser.git",
+            from: "1.3.0"
+        )
+    ],
+    targets: [
+        // Core library: domain models, persistence, repositories, services
+        // References existing iOS source files directly via path
+        .target(
+            name: "ShiftSchedulerCore",
+            dependencies: [],
+            path: "ShiftScheduler",
+            sources: [
+                // Domain models
+                "Models",
+                // Domain value objects
+                "Domain",
+                // Persistence repositories
+                "Persistence",
+                // Repository protocols
+                "Repositories",
+                // Foundation protocols (DateProviderProtocol, UserDefaultsProtocol)
+                "Protocols",
+                // Services: TimeChangeService (guards UIKit via #if canImport)
+                "Services",
+                // Redux services layer (protocols + implementations)
+                "Redux/Services",
+                // Redux error types (ScheduleError used by services)
+                "Redux/Errors"
+            ],
+            swiftSettings: [
+                .define("SWIFT_PACKAGE")
+            ]
+        ),
+        // CLI executable
+        .executableTarget(
+            name: "ShiftSchedulerCLI",
+            dependencies: [
+                "ShiftSchedulerCore",
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ],
+            path: "Sources/ShiftSchedulerCLI"
+        )
+    ]
+)

--- a/ShiftScheduler/Persistence/CloudKitManager.swift
+++ b/ShiftScheduler/Persistence/CloudKitManager.swift
@@ -6,8 +6,19 @@ import OSLog
 /// to the public CloudKit database for cross-account synchronization
 actor CloudKitManager: Sendable {
     private let logger = Logger(subsystem: "com.functioncraft.ShiftScheduler", category: "CloudKit")
-    private let container: CKContainer
-    private let publicDatabase: CKDatabase
+    private let containerIdentifier: String
+    private var cachedContainer: CKContainer?
+
+    /// CloudKit requires an icloud-services entitlement. Unbundled processes
+    /// (like the SPM-built CLI) don't have one, and CKContainer traps — it does
+    /// not throw — when used without it, so sync is compiled out for SPM builds.
+    static var isSyncAvailable: Bool {
+        #if SWIFT_PACKAGE
+        return false
+        #else
+        return true
+        #endif
+    }
 
     enum CloudKitError: Error, LocalizedError, Sendable {
         case accountNotAvailable
@@ -32,14 +43,27 @@ actor CloudKitManager: Sendable {
     }
 
     init(containerIdentifier: String = "iCloud.com.functioncraft.ShiftScheduler") {
-        self.container = CKContainer(identifier: containerIdentifier)
-        self.publicDatabase = container.publicCloudDatabase
+        self.containerIdentifier = containerIdentifier
+    }
+
+    private var container: CKContainer {
+        if let cachedContainer { return cachedContainer }
+        let container = CKContainer(identifier: containerIdentifier)
+        cachedContainer = container
+        return container
+    }
+
+    private var publicDatabase: CKDatabase {
+        container.publicCloudDatabase
     }
 
     // MARK: - Account Status
 
     /// Check if CloudKit account is available
     func checkAccountStatus() async throws -> Bool {
+        guard Self.isSyncAvailable else {
+            throw CloudKitError.accountNotAvailable
+        }
         let status = try await container.accountStatus()
         switch status {
         case .available:
@@ -196,6 +220,7 @@ actor CloudKitManager: Sendable {
 
     /// Subscribe to ShiftType changes (for real-time updates)
     func subscribeToShiftTypeChanges() async throws {
+        _ = try await checkAccountStatus()
         let subscription = CKQuerySubscription(
             recordType: "ShiftType",
             predicate: NSPredicate(value: true),
@@ -217,6 +242,7 @@ actor CloudKitManager: Sendable {
 
     /// Subscribe to Location changes (for real-time updates)
     func subscribeToLocationChanges() async throws {
+        _ = try await checkAccountStatus()
         let subscription = CKQuerySubscription(
             recordType: "Location",
             predicate: NSPredicate(value: true),

--- a/ShiftScheduler/Services/TimeChangeService.swift
+++ b/ShiftScheduler/Services/TimeChangeService.swift
@@ -1,6 +1,4 @@
 import Foundation
-import UIKit
-import Combine
 
 /// Protocol for observing significant time changes (e.g., midnight crossing, time zone changes)
 @MainActor
@@ -12,6 +10,10 @@ protocol TimeChangeServiceProtocol: Sendable {
     /// Stop observing significant time changes
     func stopObserving()
 }
+
+#if canImport(UIKit)
+import UIKit
+import Combine
 
 /// Production implementation of TimeChangeServiceProtocol
 /// Listens to UIApplication.significantTimeChangeNotification to detect:
@@ -44,3 +46,18 @@ final class TimeChangeService: TimeChangeServiceProtocol, @unchecked Sendable {
         print("[TimeChangeService] Stopped observing significant time changes")
     }
 }
+#else
+/// No-op implementation for platforms without UIKit (e.g., macOS CLI)
+@MainActor
+final class TimeChangeService: TimeChangeServiceProtocol, @unchecked Sendable {
+    nonisolated init() {}
+
+    func startObserving(onTimeChange: @escaping @Sendable () -> Void) {
+        // No-op on non-UIKit platforms
+    }
+
+    func stopObserving() {
+        // No-op on non-UIKit platforms
+    }
+}
+#endif

--- a/Sources/ShiftSchedulerCLI/CLIController.swift
+++ b/Sources/ShiftSchedulerCLI/CLIController.swift
@@ -1,0 +1,341 @@
+import Foundation
+
+/// Thin orchestration layer over the app's services for CLI operations.
+/// Not Redux: commands are one-shot, so state lives in persistence and the calendar.
+final class CLIController {
+    let persistence: PersistenceServiceProtocol
+    let calendar: CalendarServiceProtocol
+    let currentDay: CurrentDayServiceProtocol
+
+    init(dataDirectory: URL? = nil) {
+        let cloudKit = CloudKitManager()
+        let shiftTypeRepository = ShiftTypeRepository(directoryURL: dataDirectory, cloudKitManager: cloudKit)
+        persistence = PersistenceService(
+            shiftTypeRepository: shiftTypeRepository,
+            locationRepository: LocationRepository(directoryURL: dataDirectory, cloudKitManager: cloudKit),
+            changeLogRepository: ChangeLogRepository(directoryURL: dataDirectory),
+            userProfileRepository: UserProfileRepository(directoryURL: dataDirectory)
+        )
+        calendar = CalendarService(shiftTypeRepository: shiftTypeRepository)
+        currentDay = CurrentDayService()
+    }
+
+    // MARK: - Authorization
+
+    func requireCalendarAuthorization() async throws {
+        guard try await calendar.isCalendarAuthorized() else {
+            throw CLIError.calendarNotAuthorized
+        }
+    }
+
+    // MARK: - Reference resolution
+    //
+    // Commands accept UUIDs (unambiguous, agent-friendly) or human-readable
+    // names/titles/symbols (unique match required).
+
+    func resolveShiftType(_ reference: String) async throws -> ShiftType {
+        let types = try await persistence.loadShiftTypes()
+        if let id = UUID(uuidString: reference), let match = types.first(where: { $0.id == id }) {
+            return match
+        }
+        let titleMatches = types.filter { $0.title.caseInsensitiveCompare(reference) == .orderedSame }
+        if titleMatches.count == 1 { return titleMatches[0] }
+        if titleMatches.count > 1 {
+            throw CLIError.ambiguous(
+                kind: "shift type",
+                reference: reference,
+                candidates: titleMatches.map { "\($0.id.uuidString)  \($0.title)" }
+            )
+        }
+        let symbolMatches = types.filter { $0.symbol == reference }
+        if symbolMatches.count == 1 { return symbolMatches[0] }
+        if symbolMatches.count > 1 {
+            throw CLIError.ambiguous(
+                kind: "shift type",
+                reference: reference,
+                candidates: symbolMatches.map { "\($0.id.uuidString)  \($0.title)" }
+            )
+        }
+        throw CLIError.shiftTypeNotFound(reference)
+    }
+
+    func resolveLocation(_ reference: String) async throws -> Location {
+        let locations = try await persistence.loadLocations()
+        if let id = UUID(uuidString: reference), let match = locations.first(where: { $0.id == id }) {
+            return match
+        }
+        let nameMatches = locations.filter { $0.name.caseInsensitiveCompare(reference) == .orderedSame }
+        if nameMatches.count == 1 { return nameMatches[0] }
+        if nameMatches.count > 1 {
+            throw CLIError.ambiguous(
+                kind: "location",
+                reference: reference,
+                candidates: nameMatches.map { "\($0.id.uuidString)  \($0.name)" }
+            )
+        }
+        throw CLIError.locationNotFound(reference)
+    }
+
+    func findShift(eventIdentifier: String) async throws -> ScheduledShift {
+        try await requireCalendarAuthorization()
+        let shifts = try await calendar.loadShiftsForExtendedRange()
+        guard let match = shifts.first(where: { $0.eventIdentifier == eventIdentifier }) else {
+            throw CLIError.shiftNotFound(eventIdentifier)
+        }
+        return match
+    }
+
+    // MARK: - Schedule operations (with audit trail + undo stack)
+
+    func addShift(date: Date, typeReference: String, notes: String?) async throws -> ScheduledShift {
+        try await requireCalendarAuthorization()
+        let type = try await resolveShiftType(typeReference)
+        let shift = try await calendar.createShiftEvent(date: date, shiftType: type, notes: notes)
+        let entry = try await makeEntry(type: .created, date: date, old: nil, new: snapshot(type), reason: notes)
+        try await record(entry)
+        return shift
+    }
+
+    func deleteShift(eventIdentifier: String, reason: String?) async throws -> ScheduledShift {
+        let shift = try await findShift(eventIdentifier: eventIdentifier)
+        try await calendar.deleteShiftEvent(eventIdentifier: eventIdentifier)
+        let entry = try await makeEntry(
+            type: .deleted,
+            date: shift.date,
+            old: shift.shiftType.map(snapshot),
+            new: nil,
+            reason: reason
+        )
+        try await record(entry)
+        return shift
+    }
+
+    func switchShift(
+        eventIdentifier: String,
+        toTypeReference: String,
+        reason: String?
+    ) async throws -> (shift: ScheduledShift, newType: ShiftType) {
+        let shift = try await findShift(eventIdentifier: eventIdentifier)
+        let newType = try await resolveShiftType(toTypeReference)
+        if shift.shiftType?.id == newType.id {
+            throw CLIError.invalidOperation("Shift is already of type '\(newType.title)'")
+        }
+        try await calendar.updateShiftEvent(eventIdentifier: eventIdentifier, newShiftType: newType, date: shift.date)
+        let entry = try await makeEntry(
+            type: .switched,
+            date: shift.date,
+            old: shift.shiftType.map(snapshot),
+            new: snapshot(newType),
+            reason: reason
+        )
+        try await record(entry)
+        return (shift, newType)
+    }
+
+    func updateShiftNotes(eventIdentifier: String, notes: String) async throws {
+        _ = try await findShift(eventIdentifier: eventIdentifier)
+        try await calendar.updateShiftNotes(eventIdentifier: eventIdentifier, notes: notes)
+    }
+
+    // MARK: - Undo / Redo
+    //
+    // Implemented against change-log snapshots. The affected calendar event is
+    // located by date + shift type (event identifiers are not stored in
+    // ChangeLogEntry).
+
+    func undo() async throws -> ChangeLogEntry {
+        var (undoStack, redoStack) = try await persistence.loadUndoRedoStacks()
+        guard let entry = undoStack.last else { throw CLIError.nothingToUndo }
+        try await requireCalendarAuthorization()
+        try await revert(entry)
+        undoStack.removeLast()
+        redoStack.append(entry)
+        try await persistence.saveUndoRedoStacks(undo: undoStack, redo: redoStack)
+        return entry
+    }
+
+    func redo() async throws -> ChangeLogEntry {
+        var (undoStack, redoStack) = try await persistence.loadUndoRedoStacks()
+        guard let entry = redoStack.last else { throw CLIError.nothingToRedo }
+        try await requireCalendarAuthorization()
+        try await apply(entry)
+        redoStack.removeLast()
+        undoStack.append(entry)
+        try await persistence.saveUndoRedoStacks(undo: undoStack, redo: redoStack)
+        return entry
+    }
+
+    /// Reverses the effect of a change log entry (undo).
+    private func revert(_ entry: ChangeLogEntry) async throws {
+        switch entry.changeType {
+        case .switched:
+            guard let old = entry.oldShiftSnapshot, let new = entry.newShiftSnapshot else {
+                throw CLIError.cannotRevert("Change entry is missing shift snapshots")
+            }
+            let shift = try await findShift(on: entry.scheduledShiftDate, typeId: new.shiftTypeId)
+            let oldType = try await shiftType(from: old)
+            try await calendar.updateShiftEvent(eventIdentifier: shift.eventIdentifier, newShiftType: oldType, date: shift.date)
+        case .created:
+            guard let new = entry.newShiftSnapshot else {
+                throw CLIError.cannotRevert("Change entry is missing shift snapshot")
+            }
+            let shift = try await findShift(on: entry.scheduledShiftDate, typeId: new.shiftTypeId)
+            try await calendar.deleteShiftEvent(eventIdentifier: shift.eventIdentifier)
+        case .deleted:
+            guard let old = entry.oldShiftSnapshot else {
+                throw CLIError.cannotRevert("Change entry is missing shift snapshot")
+            }
+            let type = try await shiftType(from: old)
+            _ = try await calendar.createShiftEvent(date: entry.scheduledShiftDate, shiftType: type, notes: nil)
+        default:
+            throw CLIError.cannotRevert("Cannot undo a '\(entry.changeType.rawValue)' operation")
+        }
+    }
+
+    /// Re-applies the effect of a change log entry (redo).
+    private func apply(_ entry: ChangeLogEntry) async throws {
+        switch entry.changeType {
+        case .switched:
+            guard let old = entry.oldShiftSnapshot, let new = entry.newShiftSnapshot else {
+                throw CLIError.cannotRevert("Change entry is missing shift snapshots")
+            }
+            let shift = try await findShift(on: entry.scheduledShiftDate, typeId: old.shiftTypeId)
+            let newType = try await shiftType(from: new)
+            try await calendar.updateShiftEvent(eventIdentifier: shift.eventIdentifier, newShiftType: newType, date: shift.date)
+        case .created:
+            guard let new = entry.newShiftSnapshot else {
+                throw CLIError.cannotRevert("Change entry is missing shift snapshot")
+            }
+            let type = try await shiftType(from: new)
+            _ = try await calendar.createShiftEvent(date: entry.scheduledShiftDate, shiftType: type, notes: nil)
+        case .deleted:
+            guard let old = entry.oldShiftSnapshot else {
+                throw CLIError.cannotRevert("Change entry is missing shift snapshot")
+            }
+            let shift = try await findShift(on: entry.scheduledShiftDate, typeId: old.shiftTypeId)
+            try await calendar.deleteShiftEvent(eventIdentifier: shift.eventIdentifier)
+        default:
+            throw CLIError.cannotRevert("Cannot redo a '\(entry.changeType.rawValue)' operation")
+        }
+    }
+
+    // MARK: - Locations
+
+    func deleteLocation(_ reference: String) async throws -> Location {
+        let location = try await resolveLocation(reference)
+        let types = try await persistence.loadShiftTypes()
+        let dependents = types.filter { $0.location.id == location.id }
+        guard dependents.isEmpty else {
+            throw CLIError.locationInUse(name: location.name, usedBy: dependents.map(\.title))
+        }
+        try await persistence.deleteLocation(id: location.id)
+        return location
+    }
+
+    /// Saves an edited location and cascades the change to shift types and,
+    /// when the calendar is available, existing calendar events.
+    func editLocation(_ reference: String, name: String?, address: String?) async throws -> (location: Location, cascadedTypes: Int, cascadedEvents: Int) {
+        var location = try await resolveLocation(reference)
+        if let name { location.name = name }
+        if let address { location.address = address }
+        try await persistence.saveLocation(location)
+        let updatedTypes = try await persistence.updateShiftTypesWithLocation(location)
+        let cascadedEvents = await cascadeToCalendar(updatedTypes)
+        return (location, updatedTypes.count, cascadedEvents)
+    }
+
+    // MARK: - Shift types
+
+    /// Saves an edited shift type and cascades the change to existing calendar
+    /// events when the calendar is available.
+    func saveShiftTypeCascading(_ type: ShiftType) async throws -> Int {
+        try await persistence.saveShiftType(type)
+        return await cascadeToCalendar([type])
+    }
+
+    /// Best-effort calendar cascade: skipped silently when the calendar is not
+    /// authorized (persistence remains the source of truth for the edit itself).
+    private func cascadeToCalendar(_ types: [ShiftType]) async -> Int {
+        guard (try? await calendar.isCalendarAuthorized()) == true else { return 0 }
+        var count = 0
+        for type in types {
+            count += (try? await calendar.updateEventsWithShiftType(type)) ?? 0
+        }
+        return count
+    }
+
+    // MARK: - Private helpers
+
+    private func snapshot(_ type: ShiftType) -> ShiftSnapshot {
+        ShiftSnapshot(
+            shiftTypeId: type.id,
+            symbol: type.symbol,
+            title: type.title,
+            shiftDescription: type.shiftDescription,
+            duration: type.duration,
+            locationName: type.location.name,
+            locationAddress: type.location.address
+        )
+    }
+
+    private func makeEntry(
+        type: ChangeType,
+        date: Date,
+        old: ShiftSnapshot?,
+        new: ShiftSnapshot?,
+        reason: String?
+    ) async throws -> ChangeLogEntry {
+        let profile = try await persistence.loadUserProfile()
+        let name = profile.displayName.isEmpty ? "CLI" : profile.displayName
+        return ChangeLogEntry(
+            timestamp: Date(),
+            userId: profile.userId,
+            userDisplayName: name,
+            changeType: type,
+            scheduledShiftDate: date,
+            oldShiftSnapshot: old,
+            newShiftSnapshot: new,
+            reason: reason
+        )
+    }
+
+    /// Persists a change log entry and pushes it onto the undo stack
+    /// (clearing the redo stack, as any new operation invalidates redo history).
+    private func record(_ entry: ChangeLogEntry) async throws {
+        try await persistence.addChangeLogEntry(entry)
+        var (undoStack, _) = try await persistence.loadUndoRedoStacks()
+        undoStack.append(entry)
+        try await persistence.saveUndoRedoStacks(undo: undoStack, redo: [])
+    }
+
+    /// Resolves the current ShiftType for a snapshot, falling back to
+    /// reconstructing it from the snapshot when the type no longer exists.
+    private func shiftType(from snapshot: ShiftSnapshot) async throws -> ShiftType {
+        let types = try await persistence.loadShiftTypes()
+        if let match = types.first(where: { $0.id == snapshot.shiftTypeId }) {
+            return match
+        }
+        return ShiftType(
+            id: snapshot.shiftTypeId,
+            symbol: snapshot.symbol,
+            duration: snapshot.duration,
+            title: snapshot.title,
+            description: snapshot.shiftDescription,
+            location: Location(
+                name: snapshot.locationName ?? "Unknown Location",
+                address: snapshot.locationAddress ?? ""
+            )
+        )
+    }
+
+    private func findShift(on date: Date, typeId: UUID) async throws -> ScheduledShift {
+        let cal = Calendar.current
+        let start = cal.date(byAdding: .day, value: -1, to: date) ?? date
+        let end = cal.date(byAdding: .day, value: 2, to: date) ?? date
+        let shifts = try await calendar.loadShifts(from: start, to: end)
+        guard let match = shifts.first(where: { cal.isDate($0.date, inSameDayAs: date) && $0.shiftType?.id == typeId }) else {
+            throw CLIError.cannotRevert("No shift of the expected type found on \(OutputFormatter.dayString(date))")
+        }
+        return match
+    }
+}

--- a/Sources/ShiftSchedulerCLI/CLIError.swift
+++ b/Sources/ShiftSchedulerCLI/CLIError.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Errors raised by CLI commands. Each error carries a human-readable message
+/// and, where possible, an actionable suggestion for how to proceed.
+enum CLIError: Error {
+    case shiftTypeNotFound(String)
+    case locationNotFound(String)
+    case shiftNotFound(String)
+    case ambiguous(kind: String, reference: String, candidates: [String])
+    case invalidDate(String)
+    case invalidTime(String)
+    case locationInUse(name: String, usedBy: [String])
+    case nothingToUndo
+    case nothingToRedo
+    case cannotRevert(String)
+    case invalidOperation(String)
+    case confirmationRequired(String)
+    case calendarNotAuthorized
+    case cancelled
+
+    var message: String {
+        switch self {
+        case .shiftTypeNotFound(let reference):
+            return "No shift type matches '\(reference)'"
+        case .locationNotFound(let reference):
+            return "No location matches '\(reference)'"
+        case .shiftNotFound(let eventId):
+            return "No scheduled shift found with event ID '\(eventId)'"
+        case .ambiguous(let kind, let reference, let candidates):
+            return "'\(reference)' matches multiple \(kind)s:\n  " + candidates.joined(separator: "\n  ")
+        case .invalidDate(let input):
+            return "Cannot parse date '\(input)'"
+        case .invalidTime(let input):
+            return "Cannot parse time '\(input)'"
+        case .locationInUse(let name, let usedBy):
+            return "Location '\(name)' is used by shift type(s): \(usedBy.joined(separator: ", "))"
+        case .nothingToUndo:
+            return "Nothing to undo"
+        case .nothingToRedo:
+            return "Nothing to redo"
+        case .cannotRevert(let reason):
+            return reason
+        case .invalidOperation(let reason):
+            return reason
+        case .confirmationRequired(let action):
+            return "Confirmation required: \(action)"
+        case .calendarNotAuthorized:
+            return "Calendar access is not authorized"
+        case .cancelled:
+            return "Cancelled"
+        }
+    }
+
+    var suggestion: String? {
+        switch self {
+        case .shiftTypeNotFound:
+            return "Run 'shift-scheduler types list' to see available shift types. You can reference a type by UUID, title, or symbol."
+        case .locationNotFound:
+            return "Run 'shift-scheduler locations list' to see available locations. You can reference a location by UUID or name."
+        case .shiftNotFound:
+            return "Run 'shift-scheduler schedule list' to see scheduled shifts and their event IDs."
+        case .ambiguous:
+            return "Use the UUID to reference it unambiguously."
+        case .invalidDate:
+            return "Supported formats: YYYY-MM-DD, today, tomorrow, yesterday, +3d, -1w."
+        case .invalidTime:
+            return "Use 24-hour HH:MM format, e.g. 07:00 or 22:30."
+        case .locationInUse:
+            return "Edit or delete those shift types first, or point them at a different location."
+        case .confirmationRequired:
+            return "Re-run with --force to skip the confirmation prompt (no interactive terminal is available)."
+        case .calendarNotAuthorized:
+            return "Run 'shift-scheduler auth request' to grant calendar access, or check System Settings > Privacy & Security > Calendars."
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/ShiftSchedulerCLI/Commands/AuthCommand.swift
+++ b/Sources/ShiftSchedulerCLI/Commands/AuthCommand.swift
@@ -1,0 +1,59 @@
+import Foundation
+import ArgumentParser
+
+struct AuthCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "auth",
+        abstract: "Check or request calendar (EventKit) authorization.",
+        subcommands: [Status.self, Request.self],
+        defaultSubcommand: Status.self
+    )
+
+    struct Status: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "status",
+            abstract: "Report whether calendar access is authorized."
+        )
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let authorized = try await controller.calendar.isCalendarAuthorized()
+                if options.json {
+                    try OutputFormatter.printJSON(["authorized": authorized])
+                } else if authorized {
+                    print("Calendar access: authorized")
+                } else {
+                    print("Calendar access: not authorized")
+                    print("Run 'shift-scheduler auth request' to request access.")
+                }
+            }
+        }
+    }
+
+    struct Request: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "request",
+            abstract: "Request calendar access (shows the macOS permission dialog)."
+        )
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let granted = try await controller.calendar.requestCalendarAccess()
+                if options.json {
+                    try OutputFormatter.printJSON(["authorized": granted])
+                } else {
+                    print(granted ? "Calendar access granted." : "Calendar access denied.")
+                }
+                if !granted {
+                    throw ExitCode.failure
+                }
+            }
+        }
+    }
+}

--- a/Sources/ShiftSchedulerCLI/Commands/LocationsCommand.swift
+++ b/Sources/ShiftSchedulerCLI/Commands/LocationsCommand.swift
@@ -1,0 +1,165 @@
+import Foundation
+import ArgumentParser
+
+struct LocationsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "locations",
+        abstract: "Manage locations where shifts occur.",
+        subcommands: [List.self, Add.self, Edit.self, Delete.self],
+        defaultSubcommand: List.self
+    )
+
+    // MARK: - list
+
+    struct List: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "List all locations.",
+            discussion: """
+                EXAMPLES:
+                  shift-scheduler locations list
+                  shift-scheduler locations list --json
+                """
+        )
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let locations = try await controller.persistence.loadLocations()
+                if options.json {
+                    try OutputFormatter.printJSON(locations.map(LocationDTO.init))
+                } else if locations.isEmpty {
+                    print("No locations defined. Add one with 'shift-scheduler locations add'.")
+                } else {
+                    print(OutputFormatter.locationTable(locations))
+                }
+            }
+        }
+    }
+
+    // MARK: - add
+
+    struct Add: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "add",
+            abstract: "Create a new location.",
+            discussion: """
+                EXAMPLES:
+                  shift-scheduler locations add --name "Downtown" --address "123 Main St"
+                """
+        )
+
+        @Option(help: "Name of the location.")
+        var name: String
+
+        @Option(help: "Street address of the location.")
+        var address: String
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let location = Location(name: name, address: address)
+                try await controller.persistence.saveLocation(location)
+                if options.json {
+                    try OutputFormatter.printJSON(LocationDTO(location))
+                } else {
+                    print("Added location '\(location.name)'.")
+                    print("ID: \(location.id.uuidString)")
+                }
+            }
+        }
+    }
+
+    // MARK: - edit
+
+    struct Edit: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "edit",
+            abstract: "Edit an existing location.",
+            discussion: """
+                Shift types referencing this location are updated automatically, and
+                existing calendar events are updated when calendar access is authorized.
+
+                EXAMPLES:
+                  shift-scheduler locations edit --id "Downtown" --address "456 Oak Ave"
+                """
+        )
+
+        @Option(help: "Location to edit (UUID or name).")
+        var id: String
+
+        @Option(help: "New name.")
+        var name: String?
+
+        @Option(help: "New address.")
+        var address: String?
+
+        @OptionGroup var options: GlobalOptions
+
+        func validate() throws {
+            guard name != nil || address != nil else {
+                throw ValidationError("Nothing to change. Provide --name and/or --address.")
+            }
+        }
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let result = try await controller.editLocation(id, name: name, address: address)
+                if options.json {
+                    try OutputFormatter.printJSON(LocationDTO(result.location))
+                } else {
+                    print("Updated location '\(result.location.name)'.")
+                    if result.cascadedTypes > 0 {
+                        print("Updated \(result.cascadedTypes) shift type(s) referencing it.")
+                    }
+                    if result.cascadedEvents > 0 {
+                        print("Updated \(result.cascadedEvents) calendar event(s) to match.")
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - delete
+
+    struct Delete: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "delete",
+            abstract: "Delete a location.",
+            discussion: """
+                Fails if any shift type still references the location.
+
+                EXAMPLES:
+                  shift-scheduler locations delete --id "Downtown"
+                  shift-scheduler locations delete --id <UUID> --force
+                """
+        )
+
+        @Option(help: "Location to delete (UUID or name).")
+        var id: String
+
+        @Flag(help: "Skip the confirmation prompt.")
+        var force = false
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let location = try await controller.resolveLocation(id)
+                try CLIRuntime.confirm("Delete location '\(location.name)'?", force: force)
+                let deleted = try await controller.deleteLocation(id)
+                if options.json {
+                    try OutputFormatter.printJSON(LocationDTO(deleted))
+                } else {
+                    print("Deleted location '\(deleted.name)'.")
+                }
+            }
+        }
+    }
+}

--- a/Sources/ShiftSchedulerCLI/Commands/LogCommand.swift
+++ b/Sources/ShiftSchedulerCLI/Commands/LogCommand.swift
@@ -1,0 +1,99 @@
+import Foundation
+import ArgumentParser
+
+struct LogCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "log",
+        abstract: "View or purge the shift change log.",
+        subcommands: [List.self, Purge.self],
+        defaultSubcommand: List.self
+    )
+
+    // MARK: - list
+
+    struct List: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "List change log entries, newest first.",
+            discussion: """
+                EXAMPLES:
+                  shift-scheduler log list
+                  shift-scheduler log list --limit 10 --json
+                """
+        )
+
+        @Option(help: "Maximum number of entries to show.")
+        var limit: Int = 20
+
+        @OptionGroup var options: GlobalOptions
+
+        func validate() throws {
+            guard limit > 0 else {
+                throw ValidationError("--limit must be a positive number.")
+            }
+        }
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let entries = try await controller.persistence.loadChangeLogEntries()
+                    .sorted { $0.timestamp > $1.timestamp }
+                    .prefix(limit)
+                if options.json {
+                    try OutputFormatter.printJSON(entries.map(ChangeLogEntryDTO.init))
+                } else if entries.isEmpty {
+                    print("Change log is empty.")
+                } else {
+                    print(OutputFormatter.changeLogTable(Array(entries)))
+                }
+            }
+        }
+    }
+
+    // MARK: - purge
+
+    struct Purge: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "purge",
+            abstract: "Delete change log entries older than a number of days.",
+            discussion: """
+                EXAMPLES:
+                  shift-scheduler log purge --older-than 90
+                  shift-scheduler log purge --older-than 30 --force
+                """
+        )
+
+        @Option(name: .customLong("older-than"), help: "Delete entries older than this many days.")
+        var olderThan: Int
+
+        @Flag(help: "Skip the confirmation prompt.")
+        var force = false
+
+        @OptionGroup var options: GlobalOptions
+
+        func validate() throws {
+            guard olderThan > 0 else {
+                throw ValidationError("--older-than must be a positive number of days.")
+            }
+        }
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                guard let cutoff = Calendar.current.date(byAdding: .day, value: -olderThan, to: Date()) else {
+                    throw CLIError.invalidOperation("Could not compute the cutoff date")
+                }
+                try CLIRuntime.confirm(
+                    "Delete all change log entries older than \(olderThan) day(s)?",
+                    force: force
+                )
+                let deleted = try await controller.persistence.purgeOldChangeLogEntries(olderThan: cutoff)
+                if options.json {
+                    try OutputFormatter.printJSON(["deleted": deleted])
+                } else {
+                    print("Deleted \(deleted) change log entr\(deleted == 1 ? "y" : "ies").")
+                }
+            }
+        }
+    }
+}

--- a/Sources/ShiftSchedulerCLI/Commands/ProfileCommand.swift
+++ b/Sources/ShiftSchedulerCLI/Commands/ProfileCommand.swift
@@ -1,0 +1,99 @@
+import Foundation
+import ArgumentParser
+
+struct ProfileCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "profile",
+        abstract: "View or update the user profile.",
+        subcommands: [Show.self, Set.self],
+        defaultSubcommand: Show.self
+    )
+
+    // MARK: - show
+
+    struct Show: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "show",
+            abstract: "Show the current user profile.",
+            discussion: """
+                EXAMPLES:
+                  shift-scheduler profile show
+                  shift-scheduler profile show --json
+                """
+        )
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let profile = try await controller.persistence.loadUserProfile()
+                if options.json {
+                    try OutputFormatter.printJSON(ProfileDTO(profile))
+                } else {
+                    print("Display name:      \(profile.displayName.isEmpty ? "(not set)" : profile.displayName)")
+                    print("Retention policy:  \(profile.retentionPolicy.displayName)")
+                    print("Auto-purge:        \(profile.autoPurgeEnabled ? "enabled" : "disabled")")
+                    if let lastPurge = profile.lastPurgeDate {
+                        print("Last purge:        \(OutputFormatter.iso8601.string(from: lastPurge))")
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - set
+
+    struct Set: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "set",
+            abstract: "Update profile fields.",
+            discussion: """
+                Retention policies: \(ChangeLogRetentionPolicy.allCases.map(\.rawValue).joined(separator: ", "))
+
+                EXAMPLES:
+                  shift-scheduler profile set --name "Alex"
+                  shift-scheduler profile set --retention 90_days --auto-purge true
+                """
+        )
+
+        @Option(help: "New display name.")
+        var name: String?
+
+        @Option(help: "Change log retention policy.")
+        var retention: String?
+
+        @Option(name: .customLong("auto-purge"), help: "Enable or disable automatic purging (true/false).")
+        var autoPurge: Bool?
+
+        @OptionGroup var options: GlobalOptions
+
+        func validate() throws {
+            guard name != nil || retention != nil || autoPurge != nil else {
+                throw ValidationError("Nothing to change. Provide --name, --retention, and/or --auto-purge.")
+            }
+            if let retention, ChangeLogRetentionPolicy(rawValue: retention) == nil {
+                let valid = ChangeLogRetentionPolicy.allCases.map(\.rawValue).joined(separator: ", ")
+                throw ValidationError("Unknown retention policy '\(retention)'. Valid values: \(valid).")
+            }
+        }
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                var profile = try await controller.persistence.loadUserProfile()
+                if let name { profile.displayName = name }
+                if let retention, let policy = ChangeLogRetentionPolicy(rawValue: retention) {
+                    profile.retentionPolicy = policy
+                }
+                if let autoPurge { profile.autoPurgeEnabled = autoPurge }
+                try await controller.persistence.saveUserProfile(profile)
+                if options.json {
+                    try OutputFormatter.printJSON(ProfileDTO(profile))
+                } else {
+                    print("Profile updated.")
+                }
+            }
+        }
+    }
+}

--- a/Sources/ShiftSchedulerCLI/Commands/ScheduleCommand.swift
+++ b/Sources/ShiftSchedulerCLI/Commands/ScheduleCommand.swift
@@ -1,0 +1,232 @@
+import Foundation
+import ArgumentParser
+
+struct ScheduleCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "schedule",
+        abstract: "View and modify scheduled shifts in the calendar.",
+        subcommands: [List.self, Add.self, Edit.self, Delete.self, Switch.self],
+        defaultSubcommand: List.self
+    )
+
+    // MARK: - list
+
+    struct List: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "List scheduled shifts (defaults to the current month).",
+            discussion: """
+                Dates accept YYYY-MM-DD, today, tomorrow, yesterday, +3d, -1w.
+                --to is inclusive.
+
+                EXAMPLES:
+                  shift-scheduler schedule list
+                  shift-scheduler schedule list --from today --to +14d
+                  shift-scheduler schedule list --from 2026-07-01 --to 2026-07-31 --json
+                """
+        )
+
+        @Option(help: "Start date of the range.")
+        var from: String?
+
+        @Option(help: "End date of the range (inclusive).")
+        var to: String?
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+
+                let today = controller.currentDay.getTodayDate()
+                let startDate = try from.map { try DateParsing.parseDate($0) }
+                    ?? controller.currentDay.getStartOfMonth(for: today)
+                let endInclusive = try to.map { try DateParsing.parseDate($0) }
+                    ?? controller.currentDay.getEndOfMonth(for: today)
+                guard endInclusive >= startDate else {
+                    throw CLIError.invalidOperation("--to (\(OutputFormatter.dayString(endInclusive))) is before --from (\(OutputFormatter.dayString(startDate)))")
+                }
+                try await controller.requireCalendarAuthorization()
+                let endExclusive = Calendar.current.date(byAdding: .day, value: 1, to: endInclusive) ?? endInclusive
+
+                let shifts = try await controller.calendar.loadShifts(from: startDate, to: endExclusive)
+                if options.json {
+                    try OutputFormatter.printJSON(shifts.map(ShiftDTO.init))
+                } else if shifts.isEmpty {
+                    print("No shifts between \(OutputFormatter.dayString(startDate)) and \(OutputFormatter.dayString(endInclusive)).")
+                } else {
+                    print(OutputFormatter.shiftTable(shifts))
+                }
+            }
+        }
+    }
+
+    // MARK: - add
+
+    struct Add: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "add",
+            abstract: "Add a shift to the calendar and record it in the change log.",
+            discussion: """
+                EXAMPLES:
+                  shift-scheduler schedule add --date tomorrow --type "Day Shift"
+                  shift-scheduler schedule add --date 2026-07-15 --type D --notes "Covering for Sam"
+                """
+        )
+
+        @Option(help: "Date of the shift (YYYY-MM-DD, today, tomorrow, +3d, ...).")
+        var date: String
+
+        @Option(help: "Shift type to schedule (UUID, title, or symbol).")
+        var type: String
+
+        @Option(help: "Optional notes to attach to the shift.")
+        var notes: String?
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let shiftDate = try DateParsing.parseDate(date)
+                let shift = try await controller.addShift(date: shiftDate, typeReference: type, notes: notes)
+                if options.json {
+                    try OutputFormatter.printJSON(ShiftDTO(shift))
+                } else {
+                    let title = shift.shiftType.map { "\($0.symbol): \($0.title)" } ?? "shift"
+                    print("Added \(title) on \(OutputFormatter.dayString(shift.date)).")
+                    print("Event ID: \(shift.eventIdentifier)")
+                }
+            }
+        }
+    }
+
+    // MARK: - edit
+
+    struct Edit: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "edit",
+            abstract: "Edit a scheduled shift's notes.",
+            discussion: """
+                Replaces the shift's notes. Pass an empty string to clear them.
+                To change the shift type, use 'schedule switch'.
+
+                EXAMPLES:
+                  shift-scheduler schedule edit --event-id <ID> --notes "Trade with Alex"
+                  shift-scheduler schedule edit --event-id <ID> --notes ""
+                """
+        )
+
+        @Option(name: .customLong("event-id"), help: "EventKit event identifier of the shift (see 'schedule list').")
+        var eventId: String
+
+        @Option(help: "New notes for the shift (replaces existing notes; empty string clears).")
+        var notes: String
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                try await controller.updateShiftNotes(eventIdentifier: eventId, notes: notes)
+                if options.json {
+                    try OutputFormatter.printJSON(["eventId": eventId, "notes": notes])
+                } else {
+                    print(notes.isEmpty ? "Cleared notes." : "Updated notes.")
+                }
+            }
+        }
+    }
+
+    // MARK: - delete
+
+    struct Delete: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "delete",
+            abstract: "Delete a shift from the calendar and record it in the change log.",
+            discussion: """
+                Prompts for confirmation; pass --force to skip (required when no
+                interactive terminal is available).
+
+                EXAMPLES:
+                  shift-scheduler schedule delete --event-id <ID>
+                  shift-scheduler schedule delete --event-id <ID> --force --reason "Shift cancelled"
+                """
+        )
+
+        @Option(name: .customLong("event-id"), help: "EventKit event identifier of the shift (see 'schedule list').")
+        var eventId: String
+
+        @Option(help: "Optional reason recorded in the change log.")
+        var reason: String?
+
+        @Flag(help: "Skip the confirmation prompt.")
+        var force = false
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let shift = try await controller.findShift(eventIdentifier: eventId)
+                let title = shift.shiftType.map { "\($0.symbol): \($0.title)" } ?? "shift"
+                try CLIRuntime.confirm(
+                    "Delete \(title) on \(OutputFormatter.dayString(shift.date))?",
+                    force: force
+                )
+                let deleted = try await controller.deleteShift(eventIdentifier: eventId, reason: reason)
+                if options.json {
+                    try OutputFormatter.printJSON(ShiftDTO(deleted))
+                } else {
+                    print("Deleted \(title) on \(OutputFormatter.dayString(deleted.date)).")
+                }
+            }
+        }
+    }
+
+    // MARK: - switch
+
+    struct Switch: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "switch",
+            abstract: "Switch a scheduled shift to a different shift type.",
+            discussion: """
+                Records the switch in the change log with before/after snapshots,
+                so it can be undone with 'shift-scheduler undo'.
+
+                EXAMPLES:
+                  shift-scheduler schedule switch --event-id <ID> --to "Night Shift"
+                  shift-scheduler schedule switch --event-id <ID> --to N --reason "Traded with Alex"
+                """
+        )
+
+        @Option(name: .customLong("event-id"), help: "EventKit event identifier of the shift (see 'schedule list').")
+        var eventId: String
+
+        @Option(help: "New shift type (UUID, title, or symbol).")
+        var to: String
+
+        @Option(help: "Optional reason recorded in the change log.")
+        var reason: String?
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let (shift, newType) = try await controller.switchShift(
+                    eventIdentifier: eventId,
+                    toTypeReference: to,
+                    reason: reason
+                )
+                if options.json {
+                    let updated = try await controller.findShift(eventIdentifier: eventId)
+                    try OutputFormatter.printJSON(ShiftDTO(updated))
+                } else {
+                    let fromTitle = shift.shiftType.map { "\($0.symbol): \($0.title)" } ?? "(unknown)"
+                    print("Switched \(fromTitle) -> \(newType.symbol): \(newType.title) on \(OutputFormatter.dayString(shift.date)).")
+                }
+            }
+        }
+    }
+}

--- a/Sources/ShiftSchedulerCLI/Commands/TodayCommand.swift
+++ b/Sources/ShiftSchedulerCLI/Commands/TodayCommand.swift
@@ -1,0 +1,33 @@
+import Foundation
+import ArgumentParser
+
+struct TodayCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "today",
+        abstract: "Show today's scheduled shifts.",
+        discussion: """
+            EXAMPLES:
+              shift-scheduler today
+              shift-scheduler today --json
+            """
+    )
+
+    @OptionGroup var options: GlobalOptions
+
+    func run() async throws {
+        try await CLIRuntime.run(json: options.json) {
+            let controller = options.makeController()
+            try await controller.requireCalendarAuthorization()
+            let today = controller.currentDay.getTodayDate()
+            let tomorrow = controller.currentDay.getTomorrowDate()
+            let shifts = try await controller.calendar.loadShifts(from: today, to: tomorrow)
+            if options.json {
+                try OutputFormatter.printJSON(shifts.map(ShiftDTO.init))
+            } else if shifts.isEmpty {
+                print("No shifts scheduled for today (\(OutputFormatter.dayString(today))).")
+            } else {
+                print(OutputFormatter.shiftTable(shifts))
+            }
+        }
+    }
+}

--- a/Sources/ShiftSchedulerCLI/Commands/TypesCommand.swift
+++ b/Sources/ShiftSchedulerCLI/Commands/TypesCommand.swift
@@ -1,0 +1,250 @@
+import Foundation
+import ArgumentParser
+
+struct TypesCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "types",
+        abstract: "Manage shift type templates.",
+        subcommands: [List.self, Add.self, Edit.self, Delete.self],
+        defaultSubcommand: List.self
+    )
+
+    // MARK: - list
+
+    struct List: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "List all shift types.",
+            discussion: """
+                EXAMPLES:
+                  shift-scheduler types list
+                  shift-scheduler types list --json
+                """
+        )
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let types = try await controller.persistence.loadShiftTypes()
+                if options.json {
+                    try OutputFormatter.printJSON(types.map(ShiftTypeDTO.init))
+                } else if types.isEmpty {
+                    print("No shift types defined. Add one with 'shift-scheduler types add'.")
+                } else {
+                    print(OutputFormatter.shiftTypeTable(types))
+                }
+            }
+        }
+    }
+
+    // MARK: - add
+
+    struct Add: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "add",
+            abstract: "Create a new shift type.",
+            discussion: """
+                Provide either --all-day or both --start and --end (24-hour HH:MM).
+                Overnight shifts (end before start) are supported.
+
+                EXAMPLES:
+                  shift-scheduler types add --title "Day Shift" --symbol D --location "Downtown" --start 07:00 --end 15:00
+                  shift-scheduler types add --title "On Call" --symbol OC --location "Downtown" --all-day
+                """
+        )
+
+        @Option(help: "Title of the shift type.")
+        var title: String
+
+        @Option(help: "Short symbol shown in listings and calendar events (e.g. D, N, OC).")
+        var symbol: String
+
+        @Option(help: "Optional longer description.")
+        var description: String = ""
+
+        @Option(help: "Location for this shift type (UUID or name).")
+        var location: String
+
+        @Option(help: "Start time (24-hour HH:MM).")
+        var start: String?
+
+        @Option(help: "End time (24-hour HH:MM).")
+        var end: String?
+
+        @Flag(name: .customLong("all-day"), help: "Create an all-day shift type instead of a timed one.")
+        var allDay = false
+
+        @OptionGroup var options: GlobalOptions
+
+        func validate() throws {
+            if allDay {
+                guard start == nil, end == nil else {
+                    throw ValidationError("--all-day cannot be combined with --start/--end.")
+                }
+            } else {
+                guard start != nil, end != nil else {
+                    throw ValidationError("Provide both --start and --end, or use --all-day.")
+                }
+            }
+        }
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let shiftLocation = try await controller.resolveLocation(location)
+                let duration: ShiftDuration
+                if allDay {
+                    duration = .allDay
+                } else {
+                    duration = .scheduled(
+                        from: try DateParsing.parseTime(start ?? ""),
+                        to: try DateParsing.parseTime(end ?? "")
+                    )
+                }
+                let type = ShiftType(
+                    symbol: symbol,
+                    duration: duration,
+                    title: title,
+                    description: description,
+                    location: shiftLocation
+                )
+                try await controller.persistence.saveShiftType(type)
+                if options.json {
+                    try OutputFormatter.printJSON(ShiftTypeDTO(type))
+                } else {
+                    print("Added shift type '\(type.symbol): \(type.title)' (\(type.timeRangeString)).")
+                    print("ID: \(type.id.uuidString)")
+                }
+            }
+        }
+    }
+
+    // MARK: - edit
+
+    struct Edit: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "edit",
+            abstract: "Edit an existing shift type.",
+            discussion: """
+                Only the provided fields change. Changing times requires either
+                --all-day or both --start and --end. Existing calendar events using
+                this type are updated when calendar access is authorized.
+
+                EXAMPLES:
+                  shift-scheduler types edit --id "Day Shift" --symbol DS
+                  shift-scheduler types edit --id <UUID> --start 08:00 --end 16:00
+                """
+        )
+
+        @Option(help: "Shift type to edit (UUID, title, or symbol).")
+        var id: String
+
+        @Option(help: "New title.")
+        var title: String?
+
+        @Option(help: "New symbol.")
+        var symbol: String?
+
+        @Option(help: "New description.")
+        var description: String?
+
+        @Option(help: "New location (UUID or name).")
+        var location: String?
+
+        @Option(help: "New start time (24-hour HH:MM).")
+        var start: String?
+
+        @Option(help: "New end time (24-hour HH:MM).")
+        var end: String?
+
+        @Flag(name: .customLong("all-day"), help: "Make this an all-day shift type.")
+        var allDay = false
+
+        @OptionGroup var options: GlobalOptions
+
+        func validate() throws {
+            if allDay, start != nil || end != nil {
+                throw ValidationError("--all-day cannot be combined with --start/--end.")
+            }
+            if (start == nil) != (end == nil) {
+                throw ValidationError("Provide both --start and --end to change times.")
+            }
+            let anyChange = title != nil || symbol != nil || description != nil
+                || location != nil || start != nil || allDay
+            guard anyChange else {
+                throw ValidationError("Nothing to change. Provide at least one field to edit.")
+            }
+        }
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                var type = try await controller.resolveShiftType(id)
+                if let title { type.title = title }
+                if let symbol { type.symbol = symbol }
+                if let description { type.shiftDescription = description }
+                if let location {
+                    type.location = try await controller.resolveLocation(location)
+                }
+                if allDay {
+                    type.duration = .allDay
+                } else if let start, let end {
+                    type.duration = .scheduled(
+                        from: try DateParsing.parseTime(start),
+                        to: try DateParsing.parseTime(end)
+                    )
+                }
+                let cascadedEvents = try await controller.saveShiftTypeCascading(type)
+                if options.json {
+                    try OutputFormatter.printJSON(ShiftTypeDTO(type))
+                } else {
+                    print("Updated shift type '\(type.symbol): \(type.title)'.")
+                    if cascadedEvents > 0 {
+                        print("Updated \(cascadedEvents) calendar event(s) to match.")
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - delete
+
+    struct Delete: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "delete",
+            abstract: "Delete a shift type.",
+            discussion: """
+                Calendar events already scheduled with this type keep their event but
+                will show as '(unknown type)' in listings.
+
+                EXAMPLES:
+                  shift-scheduler types delete --id "Day Shift"
+                  shift-scheduler types delete --id <UUID> --force
+                """
+        )
+
+        @Option(help: "Shift type to delete (UUID, title, or symbol).")
+        var id: String
+
+        @Flag(help: "Skip the confirmation prompt.")
+        var force = false
+
+        @OptionGroup var options: GlobalOptions
+
+        func run() async throws {
+            try await CLIRuntime.run(json: options.json) {
+                let controller = options.makeController()
+                let type = try await controller.resolveShiftType(id)
+                try CLIRuntime.confirm("Delete shift type '\(type.symbol): \(type.title)'?", force: force)
+                try await controller.persistence.deleteShiftType(id: type.id)
+                if options.json {
+                    try OutputFormatter.printJSON(ShiftTypeDTO(type))
+                } else {
+                    print("Deleted shift type '\(type.symbol): \(type.title)'.")
+                }
+            }
+        }
+    }
+}

--- a/Sources/ShiftSchedulerCLI/Commands/UndoRedoCommands.swift
+++ b/Sources/ShiftSchedulerCLI/Commands/UndoRedoCommands.swift
@@ -1,0 +1,54 @@
+import Foundation
+import ArgumentParser
+
+struct UndoCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "undo",
+        abstract: "Undo the most recent schedule change (add, delete, or switch).",
+        discussion: """
+            EXAMPLES:
+              shift-scheduler undo
+              shift-scheduler undo --json
+            """
+    )
+
+    @OptionGroup var options: GlobalOptions
+
+    func run() async throws {
+        try await CLIRuntime.run(json: options.json) {
+            let controller = options.makeController()
+            let entry = try await controller.undo()
+            if options.json {
+                try OutputFormatter.printJSON(ChangeLogEntryDTO(entry))
+            } else {
+                print("Undid '\(entry.changeType.rawValue)' on \(OutputFormatter.dayString(entry.scheduledShiftDate)).")
+            }
+        }
+    }
+}
+
+struct RedoCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "redo",
+        abstract: "Re-apply the most recently undone schedule change.",
+        discussion: """
+            EXAMPLES:
+              shift-scheduler redo
+              shift-scheduler redo --json
+            """
+    )
+
+    @OptionGroup var options: GlobalOptions
+
+    func run() async throws {
+        try await CLIRuntime.run(json: options.json) {
+            let controller = options.makeController()
+            let entry = try await controller.redo()
+            if options.json {
+                try OutputFormatter.printJSON(ChangeLogEntryDTO(entry))
+            } else {
+                print("Redid '\(entry.changeType.rawValue)' on \(OutputFormatter.dayString(entry.scheduledShiftDate)).")
+            }
+        }
+    }
+}

--- a/Sources/ShiftSchedulerCLI/DateParsing.swift
+++ b/Sources/ShiftSchedulerCLI/DateParsing.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Parses CLI date and time arguments.
+enum DateParsing {
+    /// Accepted formats: YYYY-MM-DD, today, tomorrow, yesterday,
+    /// and relative offsets like +3d, -1w (days/weeks from today).
+    /// Returns the date normalized to the start of day.
+    static func parseDate(_ input: String, calendar: Calendar = .current, now: Date = Date()) throws -> Date {
+        let trimmed = input.trimmingCharacters(in: .whitespaces).lowercased()
+        let today = calendar.startOfDay(for: now)
+
+        switch trimmed {
+        case "today":
+            return today
+        case "tomorrow":
+            return calendar.date(byAdding: .day, value: 1, to: today) ?? today
+        case "yesterday":
+            return calendar.date(byAdding: .day, value: -1, to: today) ?? today
+        default:
+            break
+        }
+
+        if let relative = parseRelative(trimmed, calendar: calendar, from: today) {
+            return relative
+        }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = calendar
+        if let date = formatter.date(from: trimmed) {
+            return calendar.startOfDay(for: date)
+        }
+
+        throw CLIError.invalidDate(input)
+    }
+
+    /// Parses a 24-hour HH:MM time argument.
+    static func parseTime(_ input: String) throws -> HourMinuteTime {
+        let parts = input.trimmingCharacters(in: .whitespaces).split(separator: ":")
+        guard parts.count == 2,
+              let hour = Int(parts[0]), (0...23).contains(hour),
+              let minute = Int(parts[1]), (0...59).contains(minute) else {
+            throw CLIError.invalidTime(input)
+        }
+        return HourMinuteTime(hour: hour, minute: minute)
+    }
+
+    /// Parses +Nd/-Nd (days) and +Nw/-Nw (weeks) offsets from today.
+    private static func parseRelative(_ input: String, calendar: Calendar, from today: Date) -> Date? {
+        guard input.count >= 3 else { return nil }
+        let sign: Int
+        switch input.first {
+        case "+": sign = 1
+        case "-": sign = -1
+        default: return nil
+        }
+        let unit = input.last
+        guard let amount = Int(input.dropFirst().dropLast()), amount >= 0 else { return nil }
+        switch unit {
+        case "d":
+            return calendar.date(byAdding: .day, value: sign * amount, to: today)
+        case "w":
+            return calendar.date(byAdding: .day, value: sign * amount * 7, to: today)
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/ShiftSchedulerCLI/GlobalOptions.swift
+++ b/Sources/ShiftSchedulerCLI/GlobalOptions.swift
@@ -1,0 +1,86 @@
+import Foundation
+import ArgumentParser
+
+/// Options shared by every leaf command.
+struct GlobalOptions: ParsableArguments {
+    @Flag(help: "Output machine-readable JSON instead of human-readable text.")
+    var json = false
+
+    @Option(
+        name: .customLong("data-dir"),
+        help: "Override the data directory (default: ~/Documents/ShiftSchedulerData).",
+        completion: .directory
+    )
+    var dataDir: String?
+
+    var dataDirectoryURL: URL? {
+        dataDir.map { URL(fileURLWithPath: ($0 as NSString).expandingTildeInPath, isDirectory: true) }
+    }
+
+    func makeController() -> CLIController {
+        CLIController(dataDirectory: dataDirectoryURL)
+    }
+}
+
+/// Shared runtime helpers: error reporting that respects --json, and
+/// confirmation prompts that never hang in non-interactive contexts.
+enum CLIRuntime {
+    /// Runs a command body, converting thrown errors into JSON- or human-readable
+    /// output on stderr and a non-zero exit code.
+    static func run(json: Bool, _ body: () async throws -> Void) async throws {
+        do {
+            try await body()
+        } catch let exit as ExitCode {
+            throw exit
+        } catch {
+            emit(error, json: json)
+            throw ExitCode.failure
+        }
+    }
+
+    /// Asks for confirmation before a destructive operation.
+    /// --force skips the prompt. Without a TTY the prompt cannot be shown, so the
+    /// command fails with a clear message instead of hanging (important for
+    /// scripts and agents).
+    static func confirm(_ action: String, force: Bool) throws {
+        if force { return }
+        guard isatty(fileno(stdin)) != 0 else {
+            throw CLIError.confirmationRequired(action)
+        }
+        print("\(action) [y/N]: ", terminator: "")
+        let answer = readLine()?.trimmingCharacters(in: .whitespaces).lowercased() ?? ""
+        guard answer == "y" || answer == "yes" else {
+            throw CLIError.cancelled
+        }
+    }
+
+    private static func emit(_ error: Error, json: Bool) {
+        let (message, suggestion) = describe(error)
+        var text: String
+        if json {
+            var payload: [String: String] = ["message": message]
+            if let suggestion { payload["suggestion"] = suggestion }
+            let object = ["error": payload]
+            if let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys]),
+               let encoded = String(data: data, encoding: .utf8) {
+                text = encoded + "\n"
+            } else {
+                text = "{\"error\":{\"message\":\"\(message)\"}}\n"
+            }
+        } else {
+            text = "Error: \(message)\n"
+            if let suggestion { text += "\(suggestion)\n" }
+        }
+        FileHandle.standardError.write(Data(text.utf8))
+    }
+
+    private static func describe(_ error: Error) -> (message: String, suggestion: String?) {
+        if let cliError = error as? CLIError {
+            return (cliError.message, cliError.suggestion)
+        }
+        if let localized = error as? LocalizedError, let description = localized.errorDescription {
+            return (description, localized.recoverySuggestion)
+        }
+        return (String(describing: error), nil)
+    }
+}

--- a/Sources/ShiftSchedulerCLI/OutputFormatter.swift
+++ b/Sources/ShiftSchedulerCLI/OutputFormatter.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+// MARK: - JSON DTOs
+//
+// Stable, agent-friendly JSON shapes decoupled from the internal Codable
+// encodings of the domain models (e.g. ShiftDuration's enum encoding).
+
+struct LocationDTO: Codable {
+    let id: String
+    let name: String
+    let address: String
+
+    init(_ location: Location) {
+        id = location.id.uuidString
+        name = location.name
+        address = location.address
+    }
+}
+
+struct ShiftTypeDTO: Codable {
+    let id: String
+    let symbol: String
+    let title: String
+    let description: String
+    let allDay: Bool
+    let startTime: String?
+    let endTime: String?
+    let location: LocationDTO
+
+    init(_ type: ShiftType) {
+        id = type.id.uuidString
+        symbol = type.symbol
+        title = type.title
+        description = type.shiftDescription
+        allDay = type.isAllDay
+        startTime = type.duration.startTime.map(OutputFormatter.hhmm)
+        endTime = type.duration.endTime.map(OutputFormatter.hhmm)
+        location = LocationDTO(type.location)
+    }
+}
+
+struct ShiftDTO: Codable {
+    let eventId: String
+    let date: String
+    let endDate: String
+    let shiftType: ShiftTypeDTO?
+    let notes: String?
+    let sickDay: Bool
+    let sickReason: String?
+
+    init(_ shift: ScheduledShift) {
+        eventId = shift.eventIdentifier
+        date = OutputFormatter.dayString(shift.date)
+        endDate = OutputFormatter.dayString(shift.endDate)
+        shiftType = shift.shiftType.map(ShiftTypeDTO.init)
+        notes = shift.notes
+        sickDay = shift.isSickDay
+        sickReason = shift.reason
+    }
+}
+
+struct ChangeLogEntryDTO: Codable {
+    let id: String
+    let timestamp: String
+    let user: String
+    let changeType: String
+    let shiftDate: String
+    let from: String?
+    let to: String?
+    let reason: String?
+
+    init(_ entry: ChangeLogEntry) {
+        id = entry.id.uuidString
+        timestamp = OutputFormatter.iso8601.string(from: entry.timestamp)
+        user = entry.userDisplayName
+        changeType = entry.changeType.rawValue
+        shiftDate = OutputFormatter.dayString(entry.scheduledShiftDate)
+        from = entry.oldShiftSnapshot.map { "\($0.symbol): \($0.title)" }
+        to = entry.newShiftSnapshot.map { "\($0.symbol): \($0.title)" }
+        reason = entry.reason
+    }
+}
+
+struct ProfileDTO: Codable {
+    let userId: String
+    let displayName: String
+    let retentionPolicy: String
+    let autoPurgeEnabled: Bool
+    let lastPurgeDate: String?
+
+    init(_ profile: UserProfile) {
+        userId = profile.userId.uuidString
+        displayName = profile.displayName
+        retentionPolicy = profile.retentionPolicy.rawValue
+        autoPurgeEnabled = profile.autoPurgeEnabled
+        lastPurgeDate = profile.lastPurgeDate.map { OutputFormatter.iso8601.string(from: $0) }
+    }
+}
+
+// MARK: - Formatting
+
+enum OutputFormatter {
+    static let iso8601 = ISO8601DateFormatter()
+
+    private static let dayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
+
+    static func dayString(_ date: Date) -> String {
+        dayFormatter.string(from: date)
+    }
+
+    static func hhmm(_ time: HourMinuteTime) -> String {
+        String(format: "%02d:%02d", time.hour, time.minute)
+    }
+
+    static func printJSON<T: Encodable>(_ value: T) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(value)
+        print(String(data: data, encoding: .utf8) ?? "")
+    }
+
+    /// Renders a simple aligned text table.
+    static func table(headers: [String], rows: [[String]]) -> String {
+        var widths = headers.map { $0.count }
+        for row in rows {
+            for (index, cell) in row.enumerated() where index < widths.count {
+                widths[index] = max(widths[index], cell.count)
+            }
+        }
+        func line(_ cells: [String]) -> String {
+            zip(cells, widths)
+                .map { cell, width in cell.padding(toLength: max(width, cell.count), withPad: " ", startingAt: 0) }
+                .joined(separator: "  ")
+                .trimmingCharacters(in: .whitespaces)
+        }
+        var lines = [line(headers)]
+        lines.append(widths.map { String(repeating: "-", count: $0) }.joined(separator: "  "))
+        lines.append(contentsOf: rows.map(line))
+        return lines.joined(separator: "\n")
+    }
+
+    static func shiftTable(_ shifts: [ScheduledShift]) -> String {
+        table(
+            headers: ["DATE", "TIME", "SHIFT", "LOCATION", "SICK", "EVENT-ID"],
+            rows: shifts.map { shift in
+                [
+                    dayString(shift.date),
+                    shift.shiftType?.timeRangeString ?? "-",
+                    shift.shiftType.map { "\($0.symbol): \($0.title)" } ?? "(unknown type)",
+                    shift.shiftType?.location.name ?? "-",
+                    shift.isSickDay ? "yes" : "",
+                    shift.eventIdentifier
+                ]
+            }
+        )
+    }
+
+    static func shiftTypeTable(_ types: [ShiftType]) -> String {
+        table(
+            headers: ["ID", "SYMBOL", "TITLE", "TIME", "LOCATION"],
+            rows: types.map { type in
+                [
+                    type.id.uuidString,
+                    type.symbol,
+                    type.title,
+                    type.timeRangeString,
+                    type.location.name
+                ]
+            }
+        )
+    }
+
+    static func locationTable(_ locations: [Location]) -> String {
+        table(
+            headers: ["ID", "NAME", "ADDRESS"],
+            rows: locations.map { location in
+                [
+                    location.id.uuidString,
+                    location.name,
+                    location.address.replacingOccurrences(of: "\n", with: ", ")
+                ]
+            }
+        )
+    }
+
+    static func changeLogTable(_ entries: [ChangeLogEntry]) -> String {
+        table(
+            headers: ["TIMESTAMP", "USER", "CHANGE", "SHIFT-DATE", "FROM", "TO", "REASON"],
+            rows: entries.map { entry in
+                [
+                    iso8601.string(from: entry.timestamp),
+                    entry.userDisplayName,
+                    entry.changeType.rawValue,
+                    dayString(entry.scheduledShiftDate),
+                    entry.oldShiftSnapshot.map { "\($0.symbol): \($0.title)" } ?? "-",
+                    entry.newShiftSnapshot.map { "\($0.symbol): \($0.title)" } ?? "-",
+                    entry.reason ?? ""
+                ]
+            }
+        )
+    }
+}

--- a/Sources/ShiftSchedulerCLI/ShiftSchedulerCLI.swift
+++ b/Sources/ShiftSchedulerCLI/ShiftSchedulerCLI.swift
@@ -1,0 +1,26 @@
+import Foundation
+import ArgumentParser
+import ShiftSchedulerCore
+
+/// Root command for the shift-scheduler CLI tool.
+/// Manages shifts, shift types, locations, and schedules from the terminal,
+/// sharing data with the ShiftScheduler iOS app via ~/Documents/ShiftSchedulerData/.
+@main
+struct ShiftSchedulerCLI: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "shift-scheduler",
+        abstract: "Manage work shifts from the command line.",
+        discussion: """
+            shift-scheduler is a CLI interface for the ShiftScheduler iOS app.
+            It reads and writes to the same data directory as the iOS app
+            (~/ Documents/ShiftSchedulerData/) so changes are reflected in both.
+            """,
+        version: "1.0.0",
+        subcommands: []
+    )
+
+    mutating func run() async throws {
+        // Root command with no subcommands prints help
+        print(ShiftSchedulerCLI.helpMessage())
+    }
+}

--- a/Sources/ShiftSchedulerCLI/ShiftSchedulerCLI.swift
+++ b/Sources/ShiftSchedulerCLI/ShiftSchedulerCLI.swift
@@ -1,26 +1,51 @@
 import Foundation
 import ArgumentParser
-import ShiftSchedulerCore
 
 /// Root command for the shift-scheduler CLI tool.
-/// Manages shifts, shift types, locations, and schedules from the terminal,
-/// sharing data with the ShiftScheduler iOS app via ~/Documents/ShiftSchedulerData/.
+/// Manages shifts, shift types, locations, and schedules from the terminal.
 @main
 struct ShiftSchedulerCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "shift-scheduler",
         abstract: "Manage work shifts from the command line.",
         discussion: """
-            shift-scheduler is a CLI interface for the ShiftScheduler iOS app.
-            It reads and writes to the same data directory as the iOS app
-            (~/ Documents/ShiftSchedulerData/) so changes are reflected in both.
-            """,
-        version: "1.0.0",
-        subcommands: []
-    )
+            shift-scheduler is a CLI companion to the ShiftScheduler iOS app.
 
-    mutating func run() async throws {
-        // Root command with no subcommands prints help
-        print(ShiftSchedulerCLI.helpMessage())
-    }
+            Shift types, locations, profile, and the change log are stored as JSON
+            in ~/Documents/ShiftSchedulerData/ on this Mac (override with --data-dir).
+            Scheduled shifts live in the "functioncraft.ShiftScheduler" calendar via
+            EventKit; when that calendar is on iCloud, shifts stay in sync with the
+            iOS app. Reference data syncs through CloudKit when available.
+
+            Most commands support --json for machine-readable output. Destructive
+            commands prompt for confirmation; pass --force to skip the prompt
+            (required when running non-interactively, e.g. from a script or agent).
+
+            EXIT CODES:
+              0   Success.
+              1   Runtime failure (not found, not authorized, I/O error, cancelled).
+              64  Usage error (unknown command, bad arguments).
+
+            EXAMPLES:
+              shift-scheduler auth request
+              shift-scheduler locations add --name "Downtown" --address "123 Main St"
+              shift-scheduler types list --json
+              shift-scheduler schedule add --date tomorrow --type "Day Shift"
+              shift-scheduler schedule list --from today --to +14d
+              shift-scheduler schedule switch --event-id <ID> --to "Night Shift"
+              shift-scheduler undo
+            """,
+        version: "0.1.0",
+        subcommands: [
+            TodayCommand.self,
+            ScheduleCommand.self,
+            TypesCommand.self,
+            LocationsCommand.self,
+            LogCommand.self,
+            ProfileCommand.self,
+            AuthCommand.self,
+            UndoCommand.self,
+            RedoCommand.self
+        ]
+    )
 }


### PR DESCRIPTION
## Summary

Completes the ShiftScheduler CLI from the Phase 1 foundation stub to a fully working tool, addressing the assessment findings on this branch's predecessor (`claude/design-cli-interface-bFkQx`, whose commits are included here):

- **Full command set**: `today`, `schedule list|add|edit|delete|switch`, `types` + `locations` CRUD, `log list|purge`, `profile show|set`, `auth status|request`, and top-level `undo`/`redo`.
- **Agent-friendly by design**: `--json` on every command (success *and* error output; errors go to stderr), `--force` on destructive commands, confirmation prompts that fail fast instead of hanging when stdin is not a TTY, documented exit codes (0/1/64), and usage examples in every command's `--help`.
- **References by UUID, title/name, or symbol** with explicit ambiguity errors listing candidates.
- **Undo/redo** implemented against change-log snapshots (locating calendar events by date + shift type), writing the same `undoredo_stacks.json` the iOS app uses. Implemented in `CLIController` rather than `ShiftSwitchService`, whose `undoOperation` uses the change-log entry ID as an EventKit identifier (latent bug, untouched here).

## Notable fixes

- **CloudKit trap in CLI processes**: `CKContainer` requires an `icloud-services` entitlement and *traps uncatchably* in unbundled CLIs — every persistence command crashed (SIGTRAP). `CloudKitManager` now creates its container lazily and gates all operations behind `isSyncAvailable` (false under `#if SWIFT_PACKAGE`). iOS app behavior is unchanged; repositories already treat the thrown error as a benign offline warning.
- **Single-module executable target**: the app sources have no `public` API, so the Phase 1 `ShiftSchedulerCore` library module was unusable from a separate CLI module. The executable now compiles app + CLI sources together; test mocks and `ServiceContainer` are excluded from the shipped binary.
- **Corrected help text**: the old claim that JSON files are shared with the iOS app via `~/Documents` was wrong (iOS sandbox); sharing happens via the iCloud EventKit calendar and CloudKit. Version set to 0.1.0.

## Verification

- `swift build`: zero errors, zero warnings
- `xcodebuild build-for-testing` (iPhone 17 sim): **TEST BUILD SUCCEEDED** (app + test targets)
- Round-trip against a temp `--data-dir`: locations/types add → list `--json` → edit (with cascade) → delete; profile set/show; log purge
- Referential integrity: deleting an in-use location fails with the dependent shift types listed
- Agent-mode: every destructive command run with `stdin </dev/null` exits 1 with a clear `--force` suggestion — no hangs
- Exit codes verified: 0 success, 1 runtime failure, 64 usage error
- Calendar happy paths (`schedule add/switch`, `undo`) compile against the same service APIs the iOS middleware uses but could not be end-to-end tested here (no EventKit TCC grant in this environment); unauthorized error paths verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)