### PR TITLE
fix: give the CLI real CloudKit access and fix crashing CloudKit bugs

### DIFF
--- a/CLI.entitlements
+++ b/CLI.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.functioncraft.ShiftScheduler</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+	<key>com.apple.developer.ubiquity-container-identifiers</key>
+	<array>
+		<string>iCloud.com.functioncraft.ShiftScheduler</string>
+	</array>
+</dict>
+</plist>

--- a/ShiftScheduler.xcodeproj/project.pbxproj
+++ b/ShiftScheduler.xcodeproj/project.pbxproj
@@ -6,6 +6,11 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		6CF40981FF057D4A8DF36295 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 556A5066D9FBDD440A952F17 /* Cocoa.framework */; };
+		9DE6D95F07136A14B5F4D011 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = 25B4179DD8356CD795E8F77D /* ArgumentParser */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		B4B284BC2E7682340010D2E9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -17,24 +22,115 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0B77AB27CC36EDB81703FA8B /* shift-scheduler.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "shift-scheduler.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		556A5066D9FBDD440A952F17 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		73C5EAC44E66171E1E9CDD52 /* CLI.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = CLI.entitlements; sourceTree = "<group>"; };
 		B4B284AE2E7682320010D2E9 /* ShiftScheduler.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShiftScheduler.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4B284BB2E7682340010D2E9 /* ShiftSchedulerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShiftSchedulerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		FD1BC81D1B12115EE7889EA1 /* Exceptions for "ShiftScheduler/Redux/Services" folder in "ShiftSchedulerCLI" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				ServiceContainer.swift,
+				Mocks,
+			);
+			target = 7089690810B8BE50CA0A227A /* ShiftSchedulerCLI */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		134DC4B00234387812192904 /* ShiftScheduler/Persistence */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = ShiftScheduler/Persistence;
+			sourceTree = "<group>";
+		};
+		270A63D05903A8369DF49C10 /* ShiftScheduler/Protocols */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = ShiftScheduler/Protocols;
+			sourceTree = "<group>";
+		};
+		441374D10EBBED4394E9F819 /* Sources/ShiftSchedulerCLI */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = Sources/ShiftSchedulerCLI;
+			sourceTree = "<group>";
+		};
+		54CB606A9A03C80AA251D797 /* ShiftScheduler/Repositories */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = ShiftScheduler/Repositories;
+			sourceTree = "<group>";
+		};
+		68646DC30864DB21B75B72A8 /* ShiftScheduler/Models */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = ShiftScheduler/Models;
+			sourceTree = "<group>";
+		};
+		7635C24D785023515707522A /* ShiftScheduler/Redux/Services */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				FD1BC81D1B12115EE7889EA1 /* Exceptions for "ShiftScheduler/Redux/Services" folder in "ShiftSchedulerCLI" target */,
+			);
+			path = ShiftScheduler/Redux/Services;
+			sourceTree = "<group>";
+		};
+		AF5733ECB12A0563289C2442 /* ShiftScheduler/Redux/Errors */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = ShiftScheduler/Redux/Errors;
+			sourceTree = "<group>";
+		};
 		B4B284B02E7682320010D2E9 /* ShiftScheduler */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = ShiftScheduler;
 			sourceTree = "<group>";
 		};
 		B4B284BE2E7682340010D2E9 /* ShiftSchedulerTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = ShiftSchedulerTests;
+			sourceTree = "<group>";
+		};
+		D315BF7534ADA122188C896E /* ShiftScheduler/Domain */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = ShiftScheduler/Domain;
+			sourceTree = "<group>";
+		};
+		D71D3A277C4E20C68D2E9482 /* ShiftScheduler/Services */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = ShiftScheduler/Services;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		7E0BC85B73FA10FFDFAF557C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6CF40981FF057D4A8DF36295 /* Cocoa.framework in Frameworks */,
+				9DE6D95F07136A14B5F4D011 /* ArgumentParser in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B4B284AB2E7682320010D2E9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -52,12 +148,31 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0828405CEC24BFD00A29108E /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				556A5066D9FBDD440A952F17 /* Cocoa.framework */,
+			);
+			name = "OS X";
+			sourceTree = "<group>";
+		};
 		B4B284A52E7682320010D2E9 = {
 			isa = PBXGroup;
 			children = (
 				B4B284B02E7682320010D2E9 /* ShiftScheduler */,
 				B4B284BE2E7682340010D2E9 /* ShiftSchedulerTests */,
 				B4B284AF2E7682320010D2E9 /* Products */,
+				B5D96DE59031728317C646DF /* Frameworks */,
+				68646DC30864DB21B75B72A8 /* ShiftScheduler/Models */,
+				D315BF7534ADA122188C896E /* ShiftScheduler/Domain */,
+				134DC4B00234387812192904 /* ShiftScheduler/Persistence */,
+				54CB606A9A03C80AA251D797 /* ShiftScheduler/Repositories */,
+				270A63D05903A8369DF49C10 /* ShiftScheduler/Protocols */,
+				D71D3A277C4E20C68D2E9482 /* ShiftScheduler/Services */,
+				AF5733ECB12A0563289C2442 /* ShiftScheduler/Redux/Errors */,
+				441374D10EBBED4394E9F819 /* Sources/ShiftSchedulerCLI */,
+				7635C24D785023515707522A /* ShiftScheduler/Redux/Services */,
+				73C5EAC44E66171E1E9CDD52 /* CLI.entitlements */,
 			);
 			sourceTree = "<group>";
 		};
@@ -66,13 +181,53 @@
 			children = (
 				B4B284AE2E7682320010D2E9 /* ShiftScheduler.app */,
 				B4B284BB2E7682340010D2E9 /* ShiftSchedulerTests.xctest */,
+				0B77AB27CC36EDB81703FA8B /* shift-scheduler.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		B5D96DE59031728317C646DF /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0828405CEC24BFD00A29108E /* OS X */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		7089690810B8BE50CA0A227A /* ShiftSchedulerCLI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 045B69745DB786E398E29B87 /* Build configuration list for PBXNativeTarget "ShiftSchedulerCLI" */;
+			buildPhases = (
+				A0C6E90007017455DD3100B3 /* Sources */,
+				7E0BC85B73FA10FFDFAF557C /* Frameworks */,
+				7FAE8739B4218036E6643934 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				68646DC30864DB21B75B72A8 /* ShiftScheduler/Models */,
+				D315BF7534ADA122188C896E /* ShiftScheduler/Domain */,
+				134DC4B00234387812192904 /* ShiftScheduler/Persistence */,
+				54CB606A9A03C80AA251D797 /* ShiftScheduler/Repositories */,
+				270A63D05903A8369DF49C10 /* ShiftScheduler/Protocols */,
+				D71D3A277C4E20C68D2E9482 /* ShiftScheduler/Services */,
+				AF5733ECB12A0563289C2442 /* ShiftScheduler/Redux/Errors */,
+				441374D10EBBED4394E9F819 /* Sources/ShiftSchedulerCLI */,
+				7635C24D785023515707522A /* ShiftScheduler/Redux/Services */,
+			);
+			name = ShiftSchedulerCLI;
+			packageProductDependencies = (
+				25B4179DD8356CD795E8F77D /* ArgumentParser */,
+			);
+			productName = "shift-scheduler";
+			productReference = 0B77AB27CC36EDB81703FA8B /* shift-scheduler.app */;
+			productType = "com.apple.product-type.application";
+		};
 		B4B284AD2E7682320010D2E9 /* ShiftScheduler */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B4B284CF2E7682340010D2E9 /* Build configuration list for PBXNativeTarget "ShiftScheduler" */;
@@ -89,8 +244,6 @@
 				B4B284B02E7682320010D2E9 /* ShiftScheduler */,
 			);
 			name = ShiftScheduler;
-			packageProductDependencies = (
-			);
 			productName = ShiftScheduler;
 			productReference = B4B284AE2E7682320010D2E9 /* ShiftScheduler.app */;
 			productType = "com.apple.product-type.application";
@@ -112,8 +265,6 @@
 				B4B284BE2E7682340010D2E9 /* ShiftSchedulerTests */,
 			);
 			name = ShiftSchedulerTests;
-			packageProductDependencies = (
-			);
 			productName = ShiftSchedulerTests;
 			productReference = B4B284BB2E7682340010D2E9 /* ShiftSchedulerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -147,6 +298,7 @@
 			mainGroup = B4B284A52E7682320010D2E9;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				6F94FAFB4D4D485A07C35A4E /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = B4B284AF2E7682320010D2E9 /* Products */;
@@ -155,11 +307,19 @@
 			targets = (
 				B4B284AD2E7682320010D2E9 /* ShiftScheduler */,
 				B4B284BA2E7682340010D2E9 /* ShiftSchedulerTests */,
+				7089690810B8BE50CA0A227A /* ShiftSchedulerCLI */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		7FAE8739B4218036E6643934 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B4B284AC2E7682320010D2E9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -177,6 +337,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		A0C6E90007017455DD3100B3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B4B284AA2E7682320010D2E9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -202,6 +369,62 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		3262732354513D7109674363 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = CLI.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = M8T74C3QWG;
+				ENABLE_HARDENED_RUNTIME = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = functioncraft.ShiftScheduler;
+				PRODUCT_NAME = "shift-scheduler";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		A198BC514D1E0131DEDAA920 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = CLI.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = M8T74C3QWG;
+				ENABLE_HARDENED_RUNTIME = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = functioncraft.ShiftScheduler;
+				PRODUCT_NAME = "shift-scheduler";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
 		B4B284CD2E7682340010D2E9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -450,6 +673,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		045B69745DB786E398E29B87 /* Build configuration list for PBXNativeTarget "ShiftSchedulerCLI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3262732354513D7109674363 /* Release */,
+				A198BC514D1E0131DEDAA920 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B4B284A92E7682320010D2E9 /* Build configuration list for PBXProject "ShiftScheduler" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -478,6 +710,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		6F94FAFB4D4D485A07C35A4E /* XCRemoteSwiftPackageReference "swift-argument-parser" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-argument-parser.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		25B4179DD8356CD795E8F77D /* ArgumentParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6F94FAFB4D4D485A07C35A4E /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
+			productName = ArgumentParser;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = B4B284A62E7682320010D2E9 /* Project object */;
 }

--- a/ShiftScheduler/Persistence/CloudKitManager.swift
+++ b/ShiftScheduler/Persistence/CloudKitManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CloudKit
 import OSLog
+import Security
 
 /// Actor-based CloudKit manager for syncing shift types and locations
 /// to the public CloudKit database for cross-account synchronization
@@ -9,12 +10,25 @@ actor CloudKitManager: Sendable {
     private let containerIdentifier: String
     private var cachedContainer: CKContainer?
 
-    /// CloudKit requires an icloud-services entitlement. Unbundled processes
-    /// (like the SPM-built CLI) don't have one, and CKContainer traps — it does
-    /// not throw — when used without it, so sync is compiled out for SPM builds.
+    /// CloudKit requires the icloud-services entitlement — CKContainer traps
+    /// (does not throw) when used without it. On macOS, check the running
+    /// process's actual code-signed entitlements at runtime rather than
+    /// assuming based on build type: true for the entitled macOS app bundle,
+    /// and also true for the SPM-built CLI once it has been signed with a
+    /// matching entitlements file (see CLI.entitlements). Unsigned/unentitled
+    /// macOS processes safely get `false` instead of trapping. SecTask isn't
+    /// available on iOS, but the iOS app bundle is always properly entitled,
+    /// so sync is unconditionally available there.
     static var isSyncAvailable: Bool {
-        #if SWIFT_PACKAGE
-        return false
+        #if os(macOS)
+        guard let task = SecTaskCreateFromSelf(nil) else { return false }
+        guard let value = SecTaskCopyValueForEntitlement(
+            task,
+            "com.apple.developer.icloud-services" as CFString,
+            nil
+        ) else { return false }
+        guard let services = value as? [String] else { return false }
+        return services.contains("CloudKit")
         #else
         return true
         #endif
@@ -94,7 +108,6 @@ actor CloudKitManager: Sendable {
         _ = try await checkAccountStatus()
 
         let record = CKRecord(recordType: "ShiftType", recordID: CKRecord.ID(recordName: shiftType.id.uuidString))
-        record["recordID"] = shiftType.id.uuidString
         record["symbol"] = shiftType.symbol
         record["title"] = shiftType.title
         record["shiftDescription"] = shiftType.shiftDescription
@@ -167,7 +180,6 @@ actor CloudKitManager: Sendable {
         _ = try await checkAccountStatus()
 
         let record = CKRecord(recordType: "Location", recordID: CKRecord.ID(recordName: location.id.uuidString))
-        record["recordID"] = location.id.uuidString
         record["name"] = location.name
         record["address"] = location.address
         record["modifiedAt"] = Date()
@@ -310,12 +322,18 @@ actor CloudKitManager: Sendable {
             _ = try await fetchAllLocations()
             logger.debug("CloudKit schema already exists")
             return
-        } catch let error as CKError where error.code == .unknownItem {
+        } catch {
+            // fetchAllShiftTypes/fetchAllLocations already translate a raw
+            // CKError.unknownItem into CloudKitError.fetchFailed(message),
+            // so that's the shape we need to match here — a bare `CKError`
+            // never reaches this catch.
+            guard case CloudKitError.fetchFailed(let message) = error,
+                  message.contains("schema not configured") else {
+                // Other errors - don't try to initialize
+                throw error
+            }
             // Schema doesn't exist - create it in development
             logger.debug("CloudKit schema not found - initializing in development")
-        } catch {
-            // Other errors - don't try to initialize
-            throw error
         }
 
         // Create sample location first (ShiftType references Location)
@@ -391,8 +409,7 @@ actor CloudKitManager: Sendable {
     /// Convert CKRecord to ShiftType
     nonisolated private func shiftTypeFromRecord(_ record: CKRecord) -> ShiftType? {
         guard
-            let idString = record["recordID"] as? String,
-            let id = UUID(uuidString: idString),
+            let id = UUID(uuidString: record.recordID.recordName),
             let symbol = record["symbol"] as? String,
             let title = record["title"] as? String,
             let shiftDescription = record["shiftDescription"] as? String,
@@ -425,8 +442,7 @@ actor CloudKitManager: Sendable {
     /// Convert CKRecord to Location
     nonisolated private func locationFromRecord(_ record: CKRecord) -> Location? {
         guard
-            let idString = record["recordID"] as? String,
-            let id = UUID(uuidString: idString),
+            let id = UUID(uuidString: record.recordID.recordName),
             let name = record["name"] as? String,
             let address = record["address"] as? String
         else {

--- a/ShiftScheduler/Persistence/LocationRepository.swift
+++ b/ShiftScheduler/Persistence/LocationRepository.swift
@@ -32,6 +32,15 @@ actor LocationRepository: Sendable {
         // 1. Load from local JSON cache first (fast, doesn't block UI)
         let localLocations = try fetchLocal()
 
+        guard !localLocations.isEmpty else {
+            // Nothing local to show yet (e.g. first run on a new device/CLI
+            // invocation) — await the CloudKit fetch since there's no cached
+            // data to return in the meantime, and a detached background sync
+            // would never be observed by a one-shot process like the CLI.
+            await syncFromCloudKit()
+            return try fetchLocal()
+        }
+
         // 2. Try to sync from CloudKit in background (don't block on failure)
         Task {
             await syncFromCloudKit()

--- a/ShiftScheduler/Persistence/ShiftTypeRepository.swift
+++ b/ShiftScheduler/Persistence/ShiftTypeRepository.swift
@@ -32,6 +32,15 @@ actor ShiftTypeRepository: Sendable {
         // 1. Load from local JSON cache first (fast, doesn't block UI)
         let localShiftTypes = try fetchLocal()
 
+        guard !localShiftTypes.isEmpty else {
+            // Nothing local to show yet (e.g. first run on a new device/CLI
+            // invocation) — await the CloudKit fetch since there's no cached
+            // data to return in the meantime, and a detached background sync
+            // would never be observed by a one-shot process like the CLI.
+            await syncFromCloudKit()
+            return try fetchLocal()
+        }
+
         // 2. Try to sync from CloudKit in background (don't block on failure)
         Task {
             await syncFromCloudKit()

--- a/scripts/add_cli_target.rb
+++ b/scripts/add_cli_target.rb
@@ -1,0 +1,108 @@
+#!/usr/bin/env ruby
+require 'xcodeproj'
+
+project_path = 'ShiftScheduler.xcodeproj'
+project = Xcodeproj::Project.open(project_path)
+
+if project.targets.any? { |t| t.name == 'ShiftSchedulerCLI' }
+  abort "Target ShiftSchedulerCLI already exists — aborting to avoid duplicating."
+end
+
+# MARK: - Target
+
+target = project.new_target(:application, 'ShiftSchedulerCLI', :osx, '14.0', nil, :swift, 'shift-scheduler')
+
+team_id = 'M8T74C3QWG'
+
+common_settings = {
+  'CODE_SIGN_STYLE' => 'Automatic',
+  'DEVELOPMENT_TEAM' => team_id,
+  'CODE_SIGN_ENTITLEMENTS' => 'CLI.entitlements',
+  'PRODUCT_BUNDLE_IDENTIFIER' => 'functioncraft.ShiftSchedulerCLI',
+  'PRODUCT_NAME' => 'shift-scheduler',
+  'MACOSX_DEPLOYMENT_TARGET' => '14.0',
+  'SDKROOT' => 'macosx',
+  'SWIFT_VERSION' => '5.0',
+  'SWIFT_EMIT_LOC_STRINGS' => 'NO',
+  'ENABLE_HARDENED_RUNTIME' => 'NO',
+  'SKIP_INSTALL' => 'YES',
+  'GENERATE_INFOPLIST_FILE' => 'YES',
+  'INFOPLIST_KEY_LSUIElement' => 'YES',
+  'CURRENT_PROJECT_VERSION' => '1',
+  'MARKETING_VERSION' => '1.0',
+}
+
+target.build_configurations.each do |config|
+  common_settings.each { |k, v| config.build_settings[k] = v }
+end
+
+# MARK: - Swift Argument Parser package dependency
+
+pkg_ref = project.root_object.package_references.find do |ref|
+  ref.respond_to?(:repositoryURL) && ref.repositoryURL == 'https://github.com/apple/swift-argument-parser.git'
+end
+
+unless pkg_ref
+  pkg_ref = project.new(Xcodeproj::Project::Object::XCRemoteSwiftPackageReference)
+  pkg_ref.repositoryURL = 'https://github.com/apple/swift-argument-parser.git'
+  pkg_ref.requirement = { 'kind' => 'upToNextMajorVersion', 'minimumVersion' => '1.3.0' }
+  project.root_object.package_references << pkg_ref
+end
+
+product_dep = project.new(Xcodeproj::Project::Object::XCSwiftPackageProductDependency)
+product_dep.package = pkg_ref
+product_dep.product_name = 'ArgumentParser'
+project.root_object.attributes['TargetAttributes'] ||= {}
+
+frameworks_phase = target.frameworks_build_phase
+build_file = frameworks_phase.add_file_reference(product_dep, true) rescue nil
+if build_file.nil?
+  # Fall back to manually creating the build file referencing the package product
+  bf = project.new(Xcodeproj::Project::Object::PBXBuildFile)
+  bf.product_ref = product_dep
+  frameworks_phase.files << bf
+end
+target.package_product_dependencies << product_dep
+
+# MARK: - Source groups (filesystem-synchronized, mirroring Package.swift's whitelist)
+
+included_dirs = [
+  'ShiftScheduler/Models',
+  'ShiftScheduler/Domain',
+  'ShiftScheduler/Persistence',
+  'ShiftScheduler/Repositories',
+  'ShiftScheduler/Protocols',
+  'ShiftScheduler/Services',
+  'ShiftScheduler/Redux/Errors',
+  'Sources/ShiftSchedulerCLI',
+]
+
+included_dirs.each do |dir|
+  group = project.new(Xcodeproj::Project::Object::PBXFileSystemSynchronizedRootGroup)
+  group.path = dir
+  group.source_tree = '<group>'
+  project.main_group << group
+  target.file_system_synchronized_groups ||= []
+  target.file_system_synchronized_groups << group
+end
+
+# Redux/Services needs exceptions: exclude Mocks/ and ServiceContainer.swift (matches Package.swift's `exclude:`)
+redux_services_group = project.new(Xcodeproj::Project::Object::PBXFileSystemSynchronizedRootGroup)
+redux_services_group.path = 'ShiftScheduler/Redux/Services'
+redux_services_group.source_tree = '<group>'
+project.main_group << redux_services_group
+target.file_system_synchronized_groups << redux_services_group
+
+exception_set = project.new(Xcodeproj::Project::Object::PBXFileSystemSynchronizedBuildFileExceptionSet)
+exception_set.target = target
+exception_set.membership_exceptions = ['ServiceContainer.swift', 'Mocks']
+redux_services_group.exceptions ||= []
+redux_services_group.exceptions << exception_set
+
+# MARK: - Entitlements file reference
+
+entitlements_ref = project.main_group.new_reference('CLI.entitlements')
+entitlements_ref.source_tree = '<group>'
+
+project.save
+puts "Added target 'ShiftSchedulerCLI'."


### PR DESCRIPTION
## Summary

Investigating "the CLI doesn't see existing calendar entries" led to a much bigger finding: calendar access was never the problem (EventKit auth is TCC-based, unrelated to entitlements) — the CLI's shift-type/location catalog could never sync from CloudKit at all, so every calendar event's shift-type UUID was unresolvable and got silently dropped.

- **`CloudKitManager.isSyncAvailable`**: replaced the `#if SWIFT_PACKAGE` compile-time guard with a runtime entitlement check via `SecTask` (macOS only — iOS app bundle is always properly entitled, and `SecTask` isn't available there).
- **New `ShiftSchedulerCLI` Xcode target** (application product type, same sources as the SPM CLI target): a bare `swift build` executable or ad-hoc `codesign --entitlements` gets SIGKILL'd by AMFI for requesting restricted (iCloud) entitlements without an embedded provisioning profile. Only a real Xcode-signed `.app` bundle gets one. Uses the app's own bundle ID (`functioncraft.ShiftScheduler`) so CloudKit's container recognizes the request.
- **`ShiftTypeRepository`/`LocationRepository.fetchAll()`**: fired the CloudKit sync in an unawaited background `Task`, so a one-shot process (the CLI) would exit before it ever completed. Now awaited when the local cache is empty; still fire-and-forget when local data already exists (preserves the app's fast/non-blocking read).
- **`initializeSchemaIfNeeded()`**: caught a raw `CKError.unknownItem`, but `fetchAllShiftTypes`/`fetchAllLocations` already translate that into `CloudKitError.fetchFailed(message)` before it reaches this catch — so automatic schema initialization never actually ran, ever.
- **`saveShiftType`/`saveLocation`**: wrote to `record["recordID"]`, a CloudKit-reserved key name. Assigning it throws an **uncaught Objective-C exception that crashes the whole process** — not CLI-specific, this runs whenever the app saves a new ShiftType or Location. Removed the redundant write (the ID already lives in `CKRecord.recordID`) and fixed the two read sites to use `record.recordID.recordName`.

Also requires a one-time CloudKit Dashboard change (mark `recordName` queryable on the `ShiftType` and `Location` record types, Development environment) for schema auto-init's retry query to succeed — tracked separately, not something committable.

## Test plan
- [x] `swift build -c release` (SPM CLI target) — clean
- [x] `xcodebuild ... -scheme ShiftScheduler build` (iOS app target) — clean
- [x] `xcodebuild ... -only-testing:ShiftSchedulerTests test` — all tests pass
- [x] New `ShiftSchedulerCLI` Xcode target builds, signs with a real embedded provisioning profile, and runs without SIGKILL
- [x] Traced the CloudKit fetch failure live (temporary debug instrumentation, since removed) to confirm each fix actually resolved the error it targeted, ending at the CloudKit Dashboard schema-indexing step
- [ ] End-to-end `types list` / `schedule list` against real data — blocked on the CloudKit Dashboard queryable-index change (manual step, not part of this PR)